### PR TITLE
Fixes hashie warning for methods

### DIFF
--- a/lib/tugboat.rb
+++ b/lib/tugboat.rb
@@ -3,5 +3,11 @@ require 'tugboat/config'
 require 'tugboat/version'
 require 'json'
 
+# TODO: do this properly
+# See: https://github.com/intridea/hashie/issues/394
+require 'hashie'
+require 'hashie/logger'
+Hashie.logger = Logger.new(nil)
+
 module Tugboat
 end

--- a/tugboat.gemspec
+++ b/tugboat.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'barge', '0.12.0'
   gem.add_dependency 'middleware', '0.1.0'
   gem.add_dependency 'faraday', '0.11.0'
+  gem.add_dependency 'hashie', '3.5.5'
 
   gem.add_development_dependency 'rake', '< 11.0'
   gem.add_development_dependency 'rspec-core', '~> 2.14.0'


### PR DESCRIPTION
```
W, [2017-03-18T22:33:20.253963 #55813]  WARN -- : You are setting a key that conflicts with a built-in method Hashie::Mash#size defined in Hash. This can cause unexpected behavior when accessing the key via as a property. You can still access the key via the #[] method.
```
* Properly fix later: https://github.com/intridea/hashie/issues/391