### PR TITLE
Print the Droplet ID after create

### DIFF
--- a/lib/tugboat/middleware/create_droplet.rb
+++ b/lib/tugboat/middleware/create_droplet.rb
@@ -56,7 +56,7 @@ module Tugboat
           exit 1
         end
 
-        say 'Droplet created!'
+        say "Droplet created! Droplet ID is #{response.droplet[:id]}"
 
         @app.call(env)
       end


### PR DESCRIPTION
We have thousands of droplets on DigitalOcean, so the fuzzy search features are annoying slow. I often want to create a droplet, then immediately find its IP address so I can deploy it. This patch just makes the create command print the ID so I can call `tugboat info -i (id)`.