### PR TITLE
Adding exception for Minitest

### DIFF
--- a/license/dependency_decisions.yml
+++ b/license/dependency_decisions.yml
@@ -78,3 +78,9 @@
     :why: The OSL license is a copyleft license
     :versions: []
     :when: 2017-03-18 22:06:15.540105000 Z
+- - :approve
+  - minitest
+  - :who:
+    :why: MIT licensed but in the README, can remove when this PR merged - https://github.com/seattlerb/minitest/pull/665
+    :versions: []
+    :when: 2017-06-22 15:25:27.212303000 Z


### PR DESCRIPTION
License Finder flags it as no license. It's MIT but it's in the README.md

https://github.com/seattlerb/minitest/pull/665 will fix this