### PR TITLE
Add configurable timeout to config file and default to 90 sec

### DIFF
--- a/lib/tugboat/config.rb
+++ b/lib/tugboat/config.rb
@@ -20,6 +20,7 @@ module Tugboat
     DEFAULT_PRIVATE_NETWORKING = 'false'.freeze
     DEFAULT_BACKUPS_ENABLED = 'false'.freeze
     DEFAULT_USER_DATA = nil
+    DEFAULT_TIMEOUT = 90
 
     # Load config file from current directory, if not exit load from user's home directory
     def initialize
@@ -93,6 +94,10 @@ module Tugboat
 
     def env_access_token
       ENV['DO_API_TOKEN'] unless ENV['DO_API_TOKEN'].to_s.empty?
+    end
+
+    def timeout
+      @data['timeout'].nil? ? DEFAULT_TIMEOUT : @data['timeout']
     end
 
     # Re-runs initialize

--- a/lib/tugboat/middleware/inject_client.rb
+++ b/lib/tugboat/middleware/inject_client.rb
@@ -10,8 +10,13 @@ module Tugboat
         # Sets the digital ocean client into the environment for use
         # later.
         @access_token = env['config'].access_token
+        timeout = env['config'].timeout
 
         env['barge'] = Barge::Client.new(access_token: @access_token)
+        if not env['barge'].nil?
+          env['barge'].request_options[:timeout] = timeout
+          env['barge'].request_options[:open_timeout] = timeout
+        end
         env['droplet_kit'] = DropletKit::Client.new(access_token: @access_token)
 
         env['barge'].faraday.use CustomLogger if ENV['DEBUG']


### PR DESCRIPTION
Raise the default Barge client timeout to 90 seconds and make it configurable.

I've only briefly tested this. I'm not sure if this is the right way to add stuff to the config file. We need this because our droplet list is huge and the default 10 seconds per page timeout is too aggressive for us.