### PR TITLE
Add size slug to `tugboat droplets`

### DIFF
--- a/lib/tugboat/middleware/list_droplets.rb
+++ b/lib/tugboat/middleware/list_droplets.rb
@@ -25,7 +25,7 @@ module Tugboat
                          end
 
           public_addr = droplet.networks.v4.find { |address| address.type == 'public' }
-          say "#{droplet.name} (ip: #{public_addr.ip_address}#{private_ip}, status: #{status_color}#{droplet.status}#{CLEAR}, region: #{droplet.region.slug}, id: #{droplet.id}#{env['include_urls'] ? droplet_id_to_url(droplet.id) : ''})"
+          say "#{droplet.name} (ip: #{public_addr.ip_address}#{private_ip}, status: #{status_color}#{droplet.status}#{CLEAR}, region: #{droplet.region.slug}, size: #{droplet.size!.slug}, id: #{droplet.id}#{env['include_urls'] ? droplet_id_to_url(droplet.id) : ''})"
         end
 
         unless has_one

--- a/spec/cli/droplets_cli_spec.rb
+++ b/spec/cli/droplets_cli_spec.rb
@@ -16,9 +16,9 @@ describe Tugboat::CLI do
       cli.droplets
 
       expect($stdout.string).to eq <<-eos
-example.com (ip: 104.236.32.182, status: \e[32mactive\e[0m, region: nyc3, id: 6918990)
-example2.com (ip: 104.236.32.172, status: \e[32mactive\e[0m, region: nyc3, id: 3164956)
-example3.com (ip: 104.236.32.173, status: \e[31moff\e[0m, region: nyc3, id: 3164444)
+example.com (ip: 104.236.32.182, status: \e[32mactive\e[0m, region: nyc3, size: 512mb, id: 6918990)
+example2.com (ip: 104.236.32.172, status: \e[32mactive\e[0m, region: nyc3, size: 512mb, id: 3164956)
+example3.com (ip: 104.236.32.173, status: \e[31moff\e[0m, region: nyc3, size: 512mb, id: 3164444)
       eos
 
       expect(a_request(:get, 'https://api.digitalocean.com/v2/droplets?page=1&per_page=200')).to have_been_made
@@ -36,9 +36,9 @@ example3.com (ip: 104.236.32.173, status: \e[31moff\e[0m, region: nyc3, id: 3164
       cli.droplets
 
       expect($stdout.string).to eq <<-eos
-exampleprivate.com (ip: 104.236.32.182, private_ip: 10.131.99.89, status: \e[32mactive\e[0m, region: nyc3, id: 6918990)
-example2.com (ip: 104.236.32.172, status: \e[32mactive\e[0m, region: nyc3, id: 3164956)
-example3.com (ip: 104.236.32.173, status: \e[31moff\e[0m, region: nyc3, id: 3164444)
+exampleprivate.com (ip: 104.236.32.182, private_ip: 10.131.99.89, status: \e[32mactive\e[0m, region: nyc3, size: 512mb, id: 6918990)
+example2.com (ip: 104.236.32.172, status: \e[32mactive\e[0m, region: nyc3, size: 512mb, id: 3164956)
+example3.com (ip: 104.236.32.173, status: \e[31moff\e[0m, region: nyc3, size: 512mb, id: 3164444)
       eos
 
       expect(a_request(:get, 'https://api.digitalocean.com/v2/droplets?page=1&per_page=200')).to have_been_made
@@ -94,9 +94,9 @@ Try creating one with \e[32m`tugboat create`\e[0m
       cli.droplets
 
       expect($stdout.string).to eq <<-eos
-example.com (ip: 104.236.32.182, status: \e[32mactive\e[0m, region: nyc3, id: 6918990, url: 'https://cloud.digitalocean.com/droplets/6918990')
-example2.com (ip: 104.236.32.172, status: \e[32mactive\e[0m, region: nyc3, id: 3164956, url: 'https://cloud.digitalocean.com/droplets/3164956')
-example3.com (ip: 104.236.32.173, status: \e[31moff\e[0m, region: nyc3, id: 3164444, url: 'https://cloud.digitalocean.com/droplets/3164444')
+example.com (ip: 104.236.32.182, status: \e[32mactive\e[0m, region: nyc3, size: 512mb, id: 6918990, url: 'https://cloud.digitalocean.com/droplets/6918990')
+example2.com (ip: 104.236.32.172, status: \e[32mactive\e[0m, region: nyc3, size: 512mb, id: 3164956, url: 'https://cloud.digitalocean.com/droplets/3164956')
+example3.com (ip: 104.236.32.173, status: \e[31moff\e[0m, region: nyc3, size: 512mb, id: 3164444, url: 'https://cloud.digitalocean.com/droplets/3164444')
       eos
 
       expect(a_request(:get, 'https://api.digitalocean.com/v2/droplets?page=1&per_page=200')).to have_been_made
@@ -119,12 +119,12 @@ example3.com (ip: 104.236.32.173, status: \e[31moff\e[0m, region: nyc3, id: 3164
       cli.droplets
 
       expect($stdout.string).to eq <<-eos
-page1example.com (ip: 104.236.32.182, status: \e[32mactive\e[0m, region: nyc3, id: 6918990, url: 'https://cloud.digitalocean.com/droplets/6918990')
-page1example2.com (ip: 104.236.32.172, status: \e[32mactive\e[0m, region: nyc3, id: 3164956, url: 'https://cloud.digitalocean.com/droplets/3164956')
-page1example3.com (ip: 104.236.32.173, status: \e[31moff\e[0m, region: nyc3, id: 3164444, url: 'https://cloud.digitalocean.com/droplets/3164444')
-page2example.com (ip: 104.236.32.182, status: \e[32mactive\e[0m, region: nyc3, id: 6918990, url: 'https://cloud.digitalocean.com/droplets/6918990')
-page2example2.com (ip: 104.236.32.172, status: \e[32mactive\e[0m, region: nyc3, id: 3164956, url: 'https://cloud.digitalocean.com/droplets/3164956')
-page2example3.com (ip: 104.236.32.173, status: \e[31moff\e[0m, region: nyc3, id: 3164444, url: 'https://cloud.digitalocean.com/droplets/3164444')
+page1example.com (ip: 104.236.32.182, status: \e[32mactive\e[0m, region: nyc3, size: 512mb, id: 6918990, url: 'https://cloud.digitalocean.com/droplets/6918990')
+page1example2.com (ip: 104.236.32.172, status: \e[32mactive\e[0m, region: nyc3, size: 512mb, id: 3164956, url: 'https://cloud.digitalocean.com/droplets/3164956')
+page1example3.com (ip: 104.236.32.173, status: \e[31moff\e[0m, region: nyc3, size: 512mb, id: 3164444, url: 'https://cloud.digitalocean.com/droplets/3164444')
+page2example.com (ip: 104.236.32.182, status: \e[32mactive\e[0m, region: nyc3, size: 512mb, id: 6918990, url: 'https://cloud.digitalocean.com/droplets/6918990')
+page2example2.com (ip: 104.236.32.172, status: \e[32mactive\e[0m, region: nyc3, size: 512mb, id: 3164956, url: 'https://cloud.digitalocean.com/droplets/3164956')
+page2example3.com (ip: 104.236.32.173, status: \e[31moff\e[0m, region: nyc3, size: 512mb, id: 3164444, url: 'https://cloud.digitalocean.com/droplets/3164444')
       eos
 
       expect(a_request(:get, 'https://api.digitalocean.com/v2/droplets?page=1&per_page=200')).to have_been_made

--- a/spec/fixtures/show_droplets.json
+++ b/spec/fixtures/show_droplets.json
@@ -79,7 +79,8 @@
           "metadata"
         ],
         "available": null
-      }
+      },
+      "size": {"slug":"512mb","memory":512,"vcpus":1,"disk":20,"transfer":1.0,"price_monthly":5.0,"price_hourly":0.00744,"regions":["ams2","ams3","blr1","fra1","lon1","nyc1","nyc2","nyc3","sfo1","sfo2","sgp1","tor1"],"available":true}
     },
     {
       "id": 3164956,
@@ -160,7 +161,8 @@
           "metadata"
         ],
         "available": null
-      }
+      },
+      "size": {"slug":"512mb","memory":512,"vcpus":1,"disk":20,"transfer":1.0,"price_monthly":5.0,"price_hourly":0.00744,"regions":["ams2","ams3","blr1","fra1","lon1","nyc1","nyc2","nyc3","sfo1","sfo2","sgp1","tor1"],"available":true}
     },
   {
       "id": 3164444,
@@ -241,7 +243,8 @@
           "metadata"
         ],
         "available": null
-      }
+      },
+      "size": {"slug":"512mb","memory":512,"vcpus":1,"disk":20,"transfer":1.0,"price_monthly":5.0,"price_hourly":0.00744,"regions":["ams2","ams3","blr1","fra1","lon1","nyc1","nyc2","nyc3","sfo1","sfo2","sgp1","tor1"],"available":true}
     }
   ],
   "links": {

--- a/spec/fixtures/show_droplets_paginated_first.json
+++ b/spec/fixtures/show_droplets_paginated_first.json
@@ -79,7 +79,8 @@
           "metadata"
         ],
         "available": null
-      }
+      },
+      "size": {"slug":"512mb","memory":512,"vcpus":1,"disk":20,"transfer":1.0,"price_monthly":5.0,"price_hourly":0.00744,"regions":["ams2","ams3","blr1","fra1","lon1","nyc1","nyc2","nyc3","sfo1","sfo2","sgp1","tor1"],"available":true}
     },
     {
       "id": 3164956,
@@ -160,7 +161,8 @@
           "metadata"
         ],
         "available": null
-      }
+      },
+      "size": {"slug":"512mb","memory":512,"vcpus":1,"disk":20,"transfer":1.0,"price_monthly":5.0,"price_hourly":0.00744,"regions":["ams2","ams3","blr1","fra1","lon1","nyc1","nyc2","nyc3","sfo1","sfo2","sgp1","tor1"],"available":true}
     },
   {
       "id": 3164444,
@@ -241,7 +243,8 @@
           "metadata"
         ],
         "available": null
-      }
+      },
+      "size": {"slug":"512mb","memory":512,"vcpus":1,"disk":20,"transfer":1.0,"price_monthly":5.0,"price_hourly":0.00744,"regions":["ams2","ams3","blr1","fra1","lon1","nyc1","nyc2","nyc3","sfo1","sfo2","sgp1","tor1"],"available":true}
     }
   ],
   "links": {

--- a/spec/fixtures/show_droplets_paginated_last.json
+++ b/spec/fixtures/show_droplets_paginated_last.json
@@ -79,7 +79,8 @@
           "metadata"
         ],
         "available": null
-      }
+      },
+      "size": {"slug":"512mb","memory":512,"vcpus":1,"disk":20,"transfer":1.0,"price_monthly":5.0,"price_hourly":0.00744,"regions":["ams2","ams3","blr1","fra1","lon1","nyc1","nyc2","nyc3","sfo1","sfo2","sgp1","tor1"],"available":true}
     },
     {
       "id": 3164956,
@@ -160,7 +161,8 @@
           "metadata"
         ],
         "available": null
-      }
+      },
+      "size": {"slug":"512mb","memory":512,"vcpus":1,"disk":20,"transfer":1.0,"price_monthly":5.0,"price_hourly":0.00744,"regions":["ams2","ams3","blr1","fra1","lon1","nyc1","nyc2","nyc3","sfo1","sfo2","sgp1","tor1"],"available":true}
     },
   {
       "id": 3164444,
@@ -241,7 +243,8 @@
           "metadata"
         ],
         "available": null
-      }
+      },
+      "size": {"slug":"512mb","memory":512,"vcpus":1,"disk":20,"transfer":1.0,"price_monthly":5.0,"price_hourly":0.00744,"regions":["ams2","ams3","blr1","fra1","lon1","nyc1","nyc2","nyc3","sfo1","sfo2","sgp1","tor1"],"available":true}
     }
   ],
   "links": {

--- a/spec/fixtures/show_droplets_private_ip.json
+++ b/spec/fixtures/show_droplets_private_ip.json
@@ -85,7 +85,8 @@
           "metadata"
         ],
         "available": null
-      }
+      },
+      "size": {"slug":"512mb","memory":512,"vcpus":1,"disk":20,"transfer":1.0,"price_monthly":5.0,"price_hourly":0.00744,"regions":["ams2","ams3","blr1","fra1","lon1","nyc1","nyc2","nyc3","sfo1","sfo2","sgp1","tor1"],"available":true}
     },
     {
       "id": 3164956,
@@ -166,7 +167,8 @@
           "metadata"
         ],
         "available": null
-      }
+      },
+      "size": {"slug":"512mb","memory":512,"vcpus":1,"disk":20,"transfer":1.0,"price_monthly":5.0,"price_hourly":0.00744,"regions":["ams2","ams3","blr1","fra1","lon1","nyc1","nyc2","nyc3","sfo1","sfo2","sgp1","tor1"],"available":true}
     },
   {
       "id": 3164444,
@@ -247,7 +249,8 @@
           "metadata"
         ],
         "available": null
-      }
+      },
+      "size": {"slug":"512mb","memory":512,"vcpus":1,"disk":20,"transfer":1.0,"price_monthly":5.0,"price_hourly":0.00744,"regions":["ams2","ams3","blr1","fra1","lon1","nyc1","nyc2","nyc3","sfo1","sfo2","sgp1","tor1"],"available":true}
     }
   ],
   "links": {


### PR DESCRIPTION
Pretty self-explanatory. 

Before:
```
republic-1 (ip: 159.2.3.4, private_ip: 10.11.12.13, status: active, region: nyc3, id: 543221234)
```

After:
```
republic-1 (ip: 159.2.3.4, private_ip: 10.11.12.13, status: active, region: nyc3, size: 512mb, id: 543221234)
```
