### PR TITLE
Switches `$stdout` redirection to rspec method

### DIFF
--- a/lib/tugboat/middleware/info_droplet.rb
+++ b/lib/tugboat/middleware/info_droplet.rb
@@ -23,7 +23,7 @@ module Tugboat
 
         attribute = env['user_attribute']
 
-        droplet_ip4_public = droplet.networks.v4.find { |address| address.type == 'public' }.ip_address
+        droplet_ip4_public = droplet.networks.v4.find { |address| address.type == 'public' }.ip_address unless droplet.networks.v4.empty?
         droplet_ip6_public = droplet.networks.v6.find { |address| address.type == 'public' }.ip_address unless droplet.networks.v6.empty?
         check_private_ip   = droplet.networks.v4.find { |address| address.type == 'private' }
         droplet_private_ip = check_private_ip.ip_address if check_private_ip
@@ -59,7 +59,7 @@ module Tugboat
             say "Name:             #{droplet.name}"
             say "ID:               #{droplet.id}"
             say "Status:           #{status_color}#{droplet.status}#{CLEAR}"
-            say "IP4:              #{droplet_ip4_public}"
+            say "IP4:              #{droplet_ip4_public}" unless droplet.networks.v4.empty?
             say "IP6:              #{droplet_ip6_public}" unless droplet.networks.v6.empty?
 
             say "Private IP:       #{droplet_private_ip}" if droplet_private_ip

--- a/spec/cli/authorize_cli_spec.rb
+++ b/spec/cli/authorize_cli_spec.rb
@@ -14,37 +14,20 @@ describe Tugboat::CLI do
         with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
         to_return(status: 200, body: fixture('show_droplets'), headers: {})
 
-      expect($stdout).to receive(:print).exactly(6).times
-      expect($stdout).to receive(:print).with('Enter your access token: ')
       expect($stdin).to receive(:gets).and_return(access_token)
-      expect($stdout).to receive(:print).with('Enter your default timeout for connections in seconds (optional, defaults to 10): ')
       expect($stdin).to receive(:gets).and_return(timeout)
-      expect($stdout).to receive(:print).with('Enter your SSH key path (optional, defaults to ~/.ssh/id_rsa): ')
       expect($stdin).to receive(:gets).and_return(ssh_key_path)
-      expect($stdout).to receive(:print).with('Enter your SSH user (optional, defaults to root): ')
       expect($stdin).to receive(:gets).and_return(ssh_user)
-      expect($stdout).to receive(:print).with('Enter your SSH port number (optional, defaults to 22): ')
       expect($stdin).to receive(:gets).and_return(ssh_port)
-      expect($stdout).to receive(:print).with('Enter your default region (optional, defaults to nyc1): ')
       expect($stdin).to receive(:gets).and_return(region)
-      expect($stdout).to receive(:print).with('Enter your default image ID or image slug (optional, defaults to ubuntu-14-04-x64): ')
       expect($stdin).to receive(:gets).and_return(image)
-      expect($stdout).to receive(:print).with('Enter your default size (optional, defaults to 512mb)): ')
       expect($stdin).to receive(:gets).and_return(size)
-      expect($stdout).to receive(:print).with("Enter your default ssh key IDs (optional, defaults to none, array of IDs of ssh keys eg. ['1234']): ")
       expect($stdin).to receive(:gets).and_return(ssh_key_id)
-      expect($stdout).to receive(:print).with('Enter your default for private networking (optional, defaults to false): ')
       expect($stdin).to receive(:gets).and_return(private_networking)
-      expect($stdout).to receive(:print).with('Enter your default for enabling backups (optional, defaults to false): ')
       expect($stdin).to receive(:gets).and_return(backups_enabled)
-      expect($stdout).to receive(:print).with('Enter your default for IPv6 (optional, defaults to false): ')
       expect($stdin).to receive(:gets).and_return(ip6)
 
-      cli.authorize
-
-      expect($stdout.string).to include('Note: You can get your Access Token from https://cloud.digitalocean.com/settings/tokens/new')
-      expect($stdout.string).to include("To retrieve region, image, size and key ID's, you can use the corresponding tugboat command, such as `tugboat images`.")
-      expect($stdout.string).to include('Defaults can be changed at any time in your ~/.tugboat configuration file.')
+      expect { cli.authorize }.to output(/Note: You can get your Access Token from https:\/\/cloud.digitalocean.com\/settings\/tokens\/new/).to_stdout
 
       config = YAML.load_file(tmp_path)
 
@@ -65,37 +48,20 @@ describe Tugboat::CLI do
         with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => %r{Bearer}, 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
         to_return(status: 200, body: fixture('show_droplets'), headers: {})
 
-      expect($stdout).to receive(:print).exactly(6).times
-      expect($stdout).to receive(:print).with('Enter your access token: ')
       expect($stdin).to receive(:gets).and_return('')
-      expect($stdout).to receive(:print).with('Enter your default timeout for connections in seconds (optional, defaults to 10): ')
       expect($stdin).to receive(:gets).and_return('')
-      expect($stdout).to receive(:print).with('Enter your SSH key path (optional, defaults to ~/.ssh/id_rsa): ')
       expect($stdin).to receive(:gets).and_return('')
-      expect($stdout).to receive(:print).with('Enter your SSH user (optional, defaults to root): ')
       expect($stdin).to receive(:gets).and_return('')
-      expect($stdout).to receive(:print).with('Enter your SSH port number (optional, defaults to 22): ')
       expect($stdin).to receive(:gets).and_return('')
-      expect($stdout).to receive(:print).with('Enter your default region (optional, defaults to nyc1): ')
       expect($stdin).to receive(:gets).and_return('')
-      expect($stdout).to receive(:print).with('Enter your default image ID or image slug (optional, defaults to ubuntu-14-04-x64): ')
       expect($stdin).to receive(:gets).and_return('')
-      expect($stdout).to receive(:print).with('Enter your default size (optional, defaults to 512mb)): ')
       expect($stdin).to receive(:gets).and_return('')
-      expect($stdout).to receive(:print).with("Enter your default ssh key IDs (optional, defaults to none, array of IDs of ssh keys eg. ['1234']): ")
       expect($stdin).to receive(:gets).and_return('')
-      expect($stdout).to receive(:print).with('Enter your default for private networking (optional, defaults to false): ')
       expect($stdin).to receive(:gets).and_return('')
-      expect($stdout).to receive(:print).with('Enter your default for enabling backups (optional, defaults to false): ')
       expect($stdin).to receive(:gets).and_return('')
-      expect($stdout).to receive(:print).with('Enter your default for IPv6 (optional, defaults to false): ')
       expect($stdin).to receive(:gets).and_return('')
 
-      cli.authorize
-
-      expect($stdout.string).to include('Note: You can get your Access Token from https://cloud.digitalocean.com/settings/tokens/new')
-      expect($stdout.string).to include("To retrieve region, image, size and key ID's, you can use the corresponding tugboat command, such as `tugboat images`.")
-      expect($stdout.string).to include('Defaults can be changed at any time in your ~/.tugboat configuration file.')
+      expect { cli.authorize }.to output(/Note: You can get your Access Token from https:\/\/cloud.digitalocean.com\/settings\/tokens\/new/).to_stdout
 
       config = YAML.load_file(tmp_path)
 

--- a/spec/cli/config_cli_spec.rb
+++ b/spec/cli/config_cli_spec.rb
@@ -5,9 +5,7 @@ describe Tugboat::CLI do
 
   describe 'config' do
     it 'shows the full config' do
-      cli.config
-
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Current Config\x20
 Path: #{Dir.pwd}/tmp/tugboat
 ---
@@ -28,13 +26,14 @@ defaults:
   backups_enabled: 'false'
   ip6: 'false'
       eos
+
+      expect { cli.config }.to output(expected_string).to_stdout
     end
 
     it 'hides sensitive data if option given' do
       cli.options = cli.options.merge(hide: true)
-      cli.config
 
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Current Config (Keys Redacted)
 Path: #{Dir.pwd}/tmp/tugboat
 ---
@@ -55,6 +54,8 @@ defaults:
   backups_enabled: 'false'
   ip6: 'false'
       eos
+
+      expect { cli.config }.to output(expected_string).to_stdout
     end
   end
 end

--- a/spec/cli/create_cli_spec.rb
+++ b/spec/cli/create_cli_spec.rb
@@ -10,11 +10,11 @@ describe Tugboat::CLI do
              headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
         to_return(status: 200, body: fixture('create_droplet'), headers: {})
 
-      cli.create(droplet_name)
-
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Queueing creation of droplet '#{droplet_name}'...Droplet created! Droplet ID is 3164494
       eos
+
+      expect { cli.create(droplet_name) }.to output(expected_string).to_stdout
     end
 
     it 'with args does not use defaults from configuration' do
@@ -24,11 +24,12 @@ Queueing creation of droplet '#{droplet_name}'...Droplet created! Droplet ID is 
         to_return(status: 200, body: fixture('create_droplet'), headers: {})
 
       cli.options = cli.options.merge(image: 'ubuntu-12-04-x64', size: '1gb', region: 'nyc3', keys: 'foo_bar_key')
-      cli.create('example.com')
 
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Queueing creation of droplet 'example.com'...Droplet created! Droplet ID is 3164494
       eos
+
+      expect { cli.create('example.com') }.to output(expected_string).to_stdout
     end
 
     it 'with ip6 enable args' do
@@ -38,11 +39,12 @@ Queueing creation of droplet 'example.com'...Droplet created! Droplet ID is 3164
         to_return(status: 200, body: fixture('create_droplet'), headers: {})
 
       cli.options = cli.options.merge(ip6: 'true')
-      cli.create('example.com')
 
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Queueing creation of droplet 'example.com'...Droplet created! Droplet ID is 3164494
       eos
+
+      expect { cli.create('example.com') }.to output(expected_string).to_stdout
     end
 
     it 'with user data args' do
@@ -52,26 +54,28 @@ Queueing creation of droplet 'example.com'...Droplet created! Droplet ID is 3164
         to_return(status: 200, body: fixture('create_droplet'), headers: {})
 
       cli.options = cli.options.merge(user_data: project_path + '/spec/fixtures/user_data.sh')
-      cli.create('example.com')
 
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Queueing creation of droplet 'example.com'...Droplet created! Droplet ID is 3164494
       eos
+
+      expect { cli.create('example.com') }.to output(expected_string).to_stdout
     end
 
     it 'fails when user data file does not exist' do
       cli.options = cli.options.merge(user_data: '/foo/bar/baz.sh')
-      expect { cli.create('example.com') }.to raise_error(SystemExit)
 
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Queueing creation of droplet 'example.com'...Could not find file: /foo/bar/baz.sh, check your user_data setting
       eos
+
+      expect { expect { cli.create('example.com') }.to raise_error(SystemExit) }.to output(expected_string).to_stdout
     end
 
     context "doesn't create a droplet when mistyping help command" do
       ['help', '--help', '-h'].each do |help_attempt|
         it "tugboat create #{help_attempt}" do
-          help_text = <<-eos
+          expected_string = <<-eos
 Usage:
   rspec create NAME
 
@@ -89,8 +93,7 @@ Options:
 Create a droplet.
 eos
 
-          cli.create(help_attempt)
-          expect($stdout.string).to eq help_text
+          expect { cli.create(help_attempt) }.to output(expected_string).to_stdout
         end
       end
     end
@@ -101,11 +104,11 @@ eos
              headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
         to_return(status: 200, body: fixture('create_droplet'), headers: {})
 
-      cli.create('somethingblahblah--help')
-
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Queueing creation of droplet 'somethingblahblah--help'...Droplet created! Droplet ID is 3164494
       eos
+
+      expect { cli.create('somethingblahblah--help') }.to output(expected_string).to_stdout
     end
   end
 end

--- a/spec/cli/debug_cli_spec.rb
+++ b/spec/cli/debug_cli_spec.rb
@@ -21,12 +21,9 @@ describe Tugboat::CLI do
         with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
         to_return(status: 200, body: fixture('show_droplets'), headers: {})
 
-      cli.droplets
-
-      expect($stdout.string).to include 'Started GET request to: https://api.digitalocean.com/v2/droplets?page=1&per_page=200'
-      expect($stdout.string).to include 'DEBUG -- : Request Headers:'
-
-      expect($stdout.string).to include 'Bearer foo'
+      expect { cli.droplets }.to output(%r{DEBUG -- : Request Headers:}).to_stdout
+      expect { cli.droplets }.to output(%r{Bearer foo}).to_stdout
+      expect { cli.droplets }.to output(%r{Started GET request to}).to_stdout
     end
   end
 
@@ -47,12 +44,12 @@ describe Tugboat::CLI do
       stub_request(:get, 'https://api.digitalocean.com/v2/droplets?page=1&per_page=200').
         with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
         to_return(status: 200, body: fixture('show_droplets'), headers: {})
-      cli.droplets
 
-      expect($stdout.string).to include 'Started GET request to: https://api.digitalocean.com/v2/droplets?page=1&per_page=200'
-      expect($stdout.string).to include 'DEBUG -- : Request Headers:'
+      expect { cli.droplets }.to output(%r{Started GET request to}).to_stdout
+      expect { cli.droplets }.to output(%r{DEBUG -- : Request Headers:}).to_stdout
+      expect { cli.droplets }.to output(%r{Bearer \[TOKEN REDACTED\]}).to_stdout
 
-      expect($stdout.string).not_to include 'Bearer foo'
+      expect { cli.droplets }.not_to output(%r{Bearer foo}).to_stdout
     end
   end
 end

--- a/spec/cli/destroy_cli_spec.rb
+++ b/spec/cli/destroy_cli_spec.rb
@@ -19,11 +19,11 @@ describe Tugboat::CLI do
 
       expect($stdin).to receive(:gets).and_return('y')
 
-      cli.destroy('example.com')
-
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Droplet fuzzy name provided. Finding droplet ID...done\e[0m, 6918990 (example.com)\nWarning! Potentially destructive action. Please confirm [y/n]: Queuing destroy for 6918990 (example.com)...Deletion Successful!
 eos
+
+      expect { cli.destroy('example.com') }.to output(expected_string).to_stdout
     end
 
     it 'destroys a droplet with an id' do
@@ -38,11 +38,12 @@ eos
       expect($stdin).to receive(:gets).and_return('y')
 
       cli.options = cli.options.merge(id: '6918990')
-      cli.destroy
 
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Droplet id provided. Finding Droplet...done\e[0m, 6918990 (example.com)\nWarning! Potentially destructive action. Please confirm [y/n]: Queuing destroy for 6918990 (example.com)...Deletion Successful!
       eos
+
+      expect { cli.destroy }.to output(expected_string).to_stdout
     end
 
     it 'destroys a droplet with a name' do
@@ -61,11 +62,12 @@ Droplet id provided. Finding Droplet...done\e[0m, 6918990 (example.com)\nWarning
       expect($stdin).to receive(:gets).and_return('y')
 
       cli.options = cli.options.merge(name: 'example.com')
-      cli.destroy
 
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Droplet name provided. Finding droplet ID...done\e[0m, 6918990 (example.com)\nWarning! Potentially destructive action. Please confirm [y/n]: Queuing destroy for 6918990 (example.com)...Deletion Successful!
       eos
+
+      expect { cli.destroy }.to output(expected_string).to_stdout
     end
 
     it 'destroys a droplet with confirm flag set' do
@@ -82,12 +84,13 @@ Droplet name provided. Finding droplet ID...done\e[0m, 6918990 (example.com)\nWa
         to_return(status: 204, body: '', headers: {})
 
       cli.options = cli.options.merge(name: 'example.com', confirm: true)
-      cli.destroy
 
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Droplet name provided. Finding droplet ID...done\e[0m, 6918990 (example.com)
 Queuing destroy for 6918990 (example.com)...Deletion Successful!
       eos
+
+      expect { cli.destroy }.to output(expected_string).to_stdout
     end
 
     it 'does not destroy a droplet if no is chosen' do
@@ -101,11 +104,31 @@ Queuing destroy for 6918990 (example.com)...Deletion Successful!
 
       expect($stdin).to receive(:gets).and_return('n')
 
-      expect { cli.destroy('example.com') }.to raise_error(SystemExit)
-
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Droplet fuzzy name provided. Finding droplet ID...done\e[0m, 6918990 (example.com)\nWarning! Potentially destructive action. Please confirm [y/n]: Aborted due to user request.
       eos
+
+      expect { cli.destroy('example.com') }.to raise_error(SystemExit).and output(expected_string).to_stdout
+    end
+
+    it 'raises SystemExit when a request fails' do
+      stub_request(:get, 'https://api.digitalocean.com/v2/droplets?page=1&per_page=1').
+        with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
+        to_return(status: 200, body: fixture('show_droplets'), headers: {})
+
+      stub_request(:get, 'https://api.digitalocean.com/v2/droplets?page=1&per_page=200').
+        with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
+        to_return(status: 200, body: fixture('show_droplets'), headers: {})
+
+      stub_request(:delete, 'https://api.digitalocean.com/v2/droplets/6918990').
+        with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
+        to_return(headers: { 'Content-Type' => 'application/json' }, status: 500, body: '{"status":"ERROR","message":"Some error"}')
+
+      expect($stdin).to receive(:gets).and_return('y')
+
+      cli.options = cli.options.merge(name: 'example.com')
+
+      expect { cli.destroy }.to raise_error(SystemExit).and output(%r{Failed to destroy Droplet: Some error}).to_stdout
     end
   end
 end

--- a/spec/cli/destroy_image_cli_spec.rb
+++ b/spec/cli/destroy_image_cli_spec.rb
@@ -15,11 +15,11 @@ describe Tugboat::CLI do
 
       expect($stdin).to receive(:gets).and_return('y')
 
-      cli.destroy_image('My application image')
-
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Image fuzzy name provided. Finding image ID...done\e[0m, 6376601 (My application image)\nWarning! Potentially destructive action. Please confirm [y/n]: Queuing destroy image for 6376601 (My application image)...Image deletion successful!
       eos
+
+      expect { cli.destroy_image('My application image') }.to output(expected_string).to_stdout
     end
 
     it 'destroys an image with an id' do
@@ -34,11 +34,12 @@ Image fuzzy name provided. Finding image ID...done\e[0m, 6376601 (My application
       expect($stdin).to receive(:gets).and_return('y')
 
       cli.options = cli.options.merge(id: 6_376_601)
-      cli.destroy_image
 
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Image id provided. Finding Image...done\e[0m, 6376601 (My application image)\nWarning! Potentially destructive action. Please confirm [y/n]: Queuing destroy image for 6376601 (My application image)...Image deletion successful!
       eos
+
+      expect { cli.destroy_image }.to output(expected_string).to_stdout
     end
 
     it 'destroys an image with a name' do
@@ -52,10 +53,10 @@ Image id provided. Finding Image...done\e[0m, 6376601 (My application image)\nWa
 
       expect($stdin).to receive(:gets).and_return('y')
 
-      cli.options = cli.options.merge(name: 'My application image')
-      cli.destroy_image
+      expected_string = "Image name provided. Finding Image...done\e[0m, 6376601 (My application image)\nWarning! Potentially destructive action. Please confirm [y/n]: Queuing destroy image for 6376601 (My application image)...Image deletion successful!\n"
 
-      expect($stdout.string).to eq "Image name provided. Finding Image...done\e[0m, 6376601 (My application image)\nWarning! Potentially destructive action. Please confirm [y/n]: Queuing destroy image for 6376601 (My application image)...Image deletion successful!\n"
+      cli.options = cli.options.merge(name: 'My application image')
+      expect { cli.destroy_image }.to output(expected_string).to_stdout
     end
 
     it 'destroys an image with confirm flag set' do
@@ -69,11 +70,12 @@ Image id provided. Finding Image...done\e[0m, 6376601 (My application image)\nWa
 
       cli.options = cli.options.merge(name: 'My application image')
       cli.options = cli.options.merge(confirm: true)
-      cli.destroy_image('NLP Final')
 
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Image name provided. Finding Image...done\e[0m, 6376601 (My application image)\nQueuing destroy image for 6376601 (My application image)...Image deletion successful!
       eos
+
+      expect { cli.destroy_image('NLP Final') }.to output(expected_string).to_stdout
     end
   end
 end

--- a/spec/cli/droplets_cli_spec.rb
+++ b/spec/cli/droplets_cli_spec.rb
@@ -13,13 +13,13 @@ describe Tugboat::CLI do
         with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
         to_return(status: 200, body: fixture('show_droplets'), headers: { 'Content-Type' => 'application/json' })
 
-      cli.droplets
-
-      expect($stdout.string).to eq <<-eos
+      expected_string =   <<-eos
 example.com (ip: 104.236.32.182, status: \e[32mactive\e[0m, region: nyc3, id: 6918990)
 example2.com (ip: 104.236.32.172, status: \e[32mactive\e[0m, region: nyc3, id: 3164956)
 example3.com (ip: 104.236.32.173, status: \e[31moff\e[0m, region: nyc3, id: 3164444)
       eos
+
+      expect { cli.droplets }.to output(expected_string).to_stdout
 
       expect(a_request(:get, 'https://api.digitalocean.com/v2/droplets?page=1&per_page=200')).to have_been_made
     end
@@ -33,13 +33,13 @@ example3.com (ip: 104.236.32.173, status: \e[31moff\e[0m, region: nyc3, id: 3164
         with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
         to_return(status: 200, body: fixture('show_droplets_private_ip'), headers: { 'Content-Type' => 'application/json' })
 
-      cli.droplets
-
-      expect($stdout.string).to eq <<-eos
+      expected_string =   <<-eos
 exampleprivate.com (ip: 104.236.32.182, private_ip: 10.131.99.89, status: \e[32mactive\e[0m, region: nyc3, id: 6918990)
 example2.com (ip: 104.236.32.172, status: \e[32mactive\e[0m, region: nyc3, id: 3164956)
 example3.com (ip: 104.236.32.173, status: \e[31moff\e[0m, region: nyc3, id: 3164444)
       eos
+
+      expect { cli.droplets }.to output(expected_string).to_stdout
 
       expect(a_request(:get, 'https://api.digitalocean.com/v2/droplets?page=1&per_page=200')).to have_been_made
     end
@@ -53,12 +53,12 @@ example3.com (ip: 104.236.32.173, status: \e[31moff\e[0m, region: nyc3, id: 3164
         with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
         to_return(status: 200, body: fixture('show_droplets_empty'), headers: { 'Content-Type' => 'application/json' })
 
-      cli.droplets
-
-      expect($stdout.string).to eq <<-eos
+      expected_string =   <<-eos
 You don't appear to have any droplets.
 Try creating one with \e[32m`tugboat create`\e[0m
       eos
+
+      expect { cli.droplets }.to output(expected_string).to_stdout
 
       expect(a_request(:get, 'https://api.digitalocean.com/v2/droplets?page=1&per_page=200')).to have_been_made
     end
@@ -73,10 +73,7 @@ Try creating one with \e[32m`tugboat create`\e[0m
         to_return(status: 200, body: fixture('show_droplets'), headers: { 'Content-Type' => 'application/json' })
 
       cli.options = cli.options.merge(quiet: true)
-      cli.droplets
-
-      # Should be /dev/null not stringIO
-      expect($stdout).to be_a File
+      expect { cli.droplets }.not_to output.to_stderr
 
       expect(a_request(:get, 'https://api.digitalocean.com/v2/droplets?page=1&per_page=200')).to have_been_made
     end
@@ -91,13 +88,14 @@ Try creating one with \e[32m`tugboat create`\e[0m
         to_return(status: 200, body: fixture('show_droplets'), headers: { 'Content-Type' => 'application/json' })
 
       cli.options = cli.options.merge('include_urls' => true)
-      cli.droplets
 
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 example.com (ip: 104.236.32.182, status: \e[32mactive\e[0m, region: nyc3, id: 6918990, url: 'https://cloud.digitalocean.com/droplets/6918990')
 example2.com (ip: 104.236.32.172, status: \e[32mactive\e[0m, region: nyc3, id: 3164956, url: 'https://cloud.digitalocean.com/droplets/3164956')
 example3.com (ip: 104.236.32.173, status: \e[31moff\e[0m, region: nyc3, id: 3164444, url: 'https://cloud.digitalocean.com/droplets/3164444')
       eos
+
+      expect { cli.droplets }.to output(expected_string).to_stdout
 
       expect(a_request(:get, 'https://api.digitalocean.com/v2/droplets?page=1&per_page=200')).to have_been_made
     end
@@ -115,10 +113,7 @@ example3.com (ip: 104.236.32.173, status: \e[31moff\e[0m, region: nyc3, id: 3164
         with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
         to_return(status: 200, body: fixture('show_droplets_paginated_last'), headers: { 'Content-Type' => 'application/json' })
 
-      cli.options = cli.options.merge('include_urls' => true)
-      cli.droplets
-
-      expect($stdout.string).to eq <<-eos
+      expected_string =   <<-eos
 page1example.com (ip: 104.236.32.182, status: \e[32mactive\e[0m, region: nyc3, id: 6918990, url: 'https://cloud.digitalocean.com/droplets/6918990')
 page1example2.com (ip: 104.236.32.172, status: \e[32mactive\e[0m, region: nyc3, id: 3164956, url: 'https://cloud.digitalocean.com/droplets/3164956')
 page1example3.com (ip: 104.236.32.173, status: \e[31moff\e[0m, region: nyc3, id: 3164444, url: 'https://cloud.digitalocean.com/droplets/3164444')
@@ -126,6 +121,9 @@ page2example.com (ip: 104.236.32.182, status: \e[32mactive\e[0m, region: nyc3, i
 page2example2.com (ip: 104.236.32.172, status: \e[32mactive\e[0m, region: nyc3, id: 3164956, url: 'https://cloud.digitalocean.com/droplets/3164956')
 page2example3.com (ip: 104.236.32.173, status: \e[31moff\e[0m, region: nyc3, id: 3164444, url: 'https://cloud.digitalocean.com/droplets/3164444')
       eos
+
+      cli.options = cli.options.merge('include_urls' => true)
+      expect { cli.droplets }.to output(expected_string).to_stdout
 
       expect(a_request(:get, 'https://api.digitalocean.com/v2/droplets?page=1&per_page=200')).to have_been_made
     end

--- a/spec/cli/env_variable_spec.rb
+++ b/spec/cli/env_variable_spec.rb
@@ -15,8 +15,8 @@ describe Tugboat::CLI do
       allow(ENV).to receive(:[]).with('DEBUG').and_return(nil)
       allow(ENV).to receive(:[]).with('THOR_SHELL').and_return(nil)
 
-      cli.verify
-      expect($stdout.string).to eq "Authentication with DigitalOcean was successful.\n"
+      expected_string = "Authentication with DigitalOcean was successful.\n"
+      expect { cli.verify }.to output(expected_string).to_stdout
       expect(a_request(:get, 'https://api.digitalocean.com/v2/droplets?page=1&per_page=1')).to have_been_made
     end
 
@@ -31,8 +31,8 @@ describe Tugboat::CLI do
       allow(ENV).to receive(:[]).with('DEBUG').and_return(nil)
       allow(ENV).to receive(:[]).with('THOR_SHELL').and_return(nil)
 
-      cli.verify
-      expect($stdout.string).to eq "Authentication with DigitalOcean was successful.\n"
+      expected_string = "Authentication with DigitalOcean was successful.\n"
+      expect { cli.verify }.to output(expected_string).to_stdout
       expect(a_request(:get, 'https://api.digitalocean.com/v2/droplets?page=1&per_page=1')).to have_been_made
     end
   end

--- a/spec/cli/halt_cli_spec.rb
+++ b/spec/cli/halt_cli_spec.rb
@@ -18,12 +18,12 @@ describe Tugboat::CLI do
              headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
         to_return(status: 200, body: fixture('shutdown_response'), headers: {})
 
-      cli.halt('example.com')
-
-      expect($stdout.string).to eq <<-eos
+      expected_string =   <<-eos
 Droplet fuzzy name provided. Finding droplet ID...done\e[0m, 6918990 (example.com)
 Queuing shutdown for 6918990 (example.com)...Halt successful!
       eos
+
+      expect { cli.halt('example.com') }.to output(expected_string).to_stdout
     end
 
     it 'halts a droplet hard when the hard option is used' do
@@ -41,12 +41,13 @@ Queuing shutdown for 6918990 (example.com)...Halt successful!
         to_return(status: 200, body: '', headers: {})
 
       cli.options = cli.options.merge(hard: true)
-      cli.halt('example.com')
 
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Droplet fuzzy name provided. Finding droplet ID...done\e[0m, 6918990 (example.com)
 Queuing hard shutdown for 6918990 (example.com)...Halt successful!
       eos
+
+      expect { cli.halt('example.com') }.to output(expected_string).to_stdout
     end
 
     it 'halts a droplet with an id' do
@@ -68,12 +69,13 @@ Queuing hard shutdown for 6918990 (example.com)...Halt successful!
         to_return(status: 200, body: fixture('shutdown_response'), headers: {})
 
       cli.options = cli.options.merge(id: '6918990')
-      cli.halt
 
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Droplet id provided. Finding Droplet...done\e[0m, 6918990 (example.com)
 Queuing shutdown for 6918990 (example.com)...Halt successful!
       eos
+
+      expect { cli.halt }.to output(expected_string).to_stdout
     end
 
     it 'halts a droplet with a name' do
@@ -91,12 +93,13 @@ Queuing shutdown for 6918990 (example.com)...Halt successful!
         to_return(status: 200, body: fixture('shutdown_response'), headers: {})
 
       cli.options = cli.options.merge(name: 'example.com')
-      cli.halt
 
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Droplet name provided. Finding droplet ID...done\e[0m, 6918990 (example.com)
 Queuing shutdown for 6918990 (example.com)...Halt successful!
       eos
+
+      expect { cli.halt }.to output(expected_string).to_stdout
     end
 
     it 'does not halt a droplet that is off' do
@@ -108,13 +111,13 @@ Queuing shutdown for 6918990 (example.com)...Halt successful!
         with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
         to_return(status: 200, body: fixture('show_droplets'), headers: { 'Content-Type' => 'application/json' })
 
-      cli.options = cli.options.merge(name: 'example3.com')
-      expect { cli.halt }.to raise_error(SystemExit)
-
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Droplet name provided. Finding droplet ID...done\e[0m, 3164444 (example3.com)
 Droplet must be on for this operation to be successful.
       eos
+
+      cli.options = cli.options.merge(name: 'example3.com')
+      expect { cli.halt }.to raise_error(SystemExit).and output(expected_string).to_stdout
     end
   end
 end

--- a/spec/cli/help_cli_spec.rb
+++ b/spec/cli/help_cli_spec.rb
@@ -5,13 +5,13 @@ describe Tugboat::CLI do
 
   describe 'help' do
     it 'shows a help message' do
-      cli.help
-      expect($stdout.string).to match('Commands:')
+      expected_string = %r{To learn more or to contribute, please see}
+      expect { cli.help }.to output(expected_string).to_stdout
     end
 
     it 'shows a help message for specific commands' do
-      cli.help 'sizes'
-      expect($stdout.string).to match('Usage:')
+      expected_string = %r{Show available droplet sizes}
+      expect { cli.help 'sizes' }.to output(expected_string).to_stdout
     end
   end
 end

--- a/spec/cli/images_cli_spec.rb
+++ b/spec/cli/images_cli_spec.rb
@@ -13,9 +13,7 @@ describe Tugboat::CLI do
         with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
         to_return(status: 200, body: fixture('show_images_global'), headers: {})
 
-      cli.images
-
-      expect($stdout.string).to eq <<-eos
+      expected_string =   <<-eos
 Showing both private and public images
 Private Images:
 My application image (id: 6376601, distro: Ubuntu)
@@ -71,6 +69,8 @@ MediaWiki 1.24.2 on 14.04 (slug: mediawiki, id: 11716043, distro: Ubuntu)
 PHPMyAdmin on 14.04 (slug: phpmyadmin, id: 11730661, distro: Ubuntu)
 Redmine on 14.04 (slug: redmine, id: 12438838, distro: Ubuntu)
       eos
+
+      expect { cli.images }.to output(expected_string).to_stdout
     end
 
     it 'acknowledges when personal images are empty when showing default full list' do
@@ -83,9 +83,8 @@ Redmine on 14.04 (slug: redmine, id: 12438838, distro: Ubuntu)
         to_return(status: 200, body: fixture('show_images_empty'), headers: {})
 
       cli.options = cli.options.merge(show_private_images: true)
-      cli.images
 
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Showing both private and public images
 Private Images:
 No private images found
@@ -141,6 +140,8 @@ MediaWiki 1.24.2 on 14.04 (slug: mediawiki, id: 11716043, distro: Ubuntu)
 PHPMyAdmin on 14.04 (slug: phpmyadmin, id: 11730661, distro: Ubuntu)
 Redmine on 14.04 (slug: redmine, id: 12438838, distro: Ubuntu)
       eos
+
+      expect { cli.images }.to output(expected_string).to_stdout
     end
 
     it 'acknowledges when personal images are empty when just show private images flag given' do
@@ -153,13 +154,14 @@ Redmine on 14.04 (slug: redmine, id: 12438838, distro: Ubuntu)
         to_return(status: 200, body: fixture('show_images_empty'), headers: {})
 
       cli.options = cli.options.merge(show_just_private_images: true)
-      cli.images
 
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Showing just private images
 Private Images:
 No private images found
       eos
+
+      expect { cli.images }.to output(expected_string).to_stdout
     end
   end
 end

--- a/spec/cli/info_cli_spec.rb
+++ b/spec/cli/info_cli_spec.rb
@@ -15,11 +15,11 @@ describe Tugboat::CLI do
 
       cli.options = cli.options.merge(id: 6_918_990)
 
-      expect { cli.info }.to raise_error(SystemExit)
-
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Droplet id provided. Finding Droplet...Failed to find Droplet: The resource you were accessing could not be found.
       eos
+
+      expect { cli.info }.to raise_error(SystemExit).and output(expected_string).to_stdout
 
       expect(a_request(:get, 'https://api.digitalocean.com/v2/droplets/6918990?per_page=200')).to have_been_made
     end
@@ -37,9 +37,7 @@ Droplet id provided. Finding Droplet...Failed to find Droplet: The resource you 
         with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
         to_return(status: 200, body: fixture('show_droplet'), headers: {})
 
-      cli.info('example.com')
-
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Droplet fuzzy name provided. Finding droplet ID...done\e[0m, 6918990 (example.com)
 
 Name:             example.com
@@ -52,6 +50,8 @@ Image:            6918990 - ubuntu-14-04-x64
 Size:             512MB
 Backups Active:   false
       eos
+
+      expect { cli.info('example.com') }.to output(expected_string).to_stdout
     end
 
     it 'shows a droplet made from a user image' do
@@ -63,10 +63,7 @@ Backups Active:   false
         with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
         to_return(status: 200, body: fixture('show_droplet_user_image'), headers: {})
 
-      cli.options = cli.options.merge(id: 6_918_990)
-      cli.info
-
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Droplet id provided. Finding Droplet...done\e[0m, 6918990 (example.com)
 
 Name:             example.com
@@ -79,6 +76,9 @@ Image:            36646276 - Super Cool Custom Image
 Size:             512MB
 Backups Active:   false
       eos
+
+      cli.options = cli.options.merge(id: 6_918_990)
+      expect { cli.info }.to output(expected_string).to_stdout
     end
 
     it 'shows a droplet with an id' do
@@ -90,10 +90,7 @@ Backups Active:   false
         with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
         to_return(status: 200, body: fixture('show_droplet'), headers: {})
 
-      cli.options = cli.options.merge(id: 6_918_990)
-      cli.info
-
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Droplet id provided. Finding Droplet...done\e[0m, 6918990 (example.com)
 
 Name:             example.com
@@ -106,6 +103,9 @@ Image:            6918990 - ubuntu-14-04-x64
 Size:             512MB
 Backups Active:   false
       eos
+
+      cli.options = cli.options.merge(id: 6_918_990)
+      expect { cli.info }.to output(expected_string).to_stdout
     end
 
     it 'shows a droplet with a name' do
@@ -121,10 +121,7 @@ Backups Active:   false
         with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
         to_return(status: 200, body: fixture('show_droplet'), headers: {})
 
-      cli.options = cli.options.merge(name: 'example.com')
-      cli.info
-
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Droplet name provided. Finding droplet ID...done\e[0m, 6918990 (example.com)
 
 Name:             example.com
@@ -137,6 +134,9 @@ Image:            6918990 - ubuntu-14-04-x64
 Size:             512MB
 Backups Active:   false
       eos
+
+      cli.options = cli.options.merge(name: 'example.com')
+      expect { cli.info }.to output(expected_string).to_stdout
     end
 
     it 'allows choice of multiple droplets' do
@@ -154,9 +154,7 @@ Backups Active:   false
 
       expect($stdin).to receive(:gets).and_return('0')
 
-      cli.info('examp')
-
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Droplet fuzzy name provided. Finding droplet ID...Multiple droplets found.
 
 0) example.com (6918990)
@@ -174,6 +172,8 @@ Image:            6918990 - ubuntu-14-04-x64
 Size:             512MB
 Backups Active:   false
       eos
+
+      expect { cli.info('examp') }.to output(expected_string).to_stdout
     end
   end
 
@@ -186,10 +186,7 @@ Backups Active:   false
       with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
       to_return(status: 200, body: fixture('show_droplet'), headers: {})
 
-    cli.options = cli.options.merge(id: '6918990', porcelain: true)
-    cli.info
-
-    expect($stdout.string).to eq <<-eos
+    expected_string = <<-eos
 name example.com
 id 6918990
 status active
@@ -200,6 +197,9 @@ image 6918990
 size 512mb
 backups_active false
       eos
+
+    cli.options = cli.options.merge(id: '6918990', porcelain: true)
+    expect { cli.info }.to output(expected_string).to_stdout
   end
 
   it 'shows a droplet with a name under porcelain mode' do
@@ -215,10 +215,7 @@ backups_active false
       with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
       to_return(status: 200, body: fixture('show_droplet'), headers: {})
 
-    cli.options = cli.options.merge(name: 'example.com', porcelain: true)
-    cli.info
-
-    expect($stdout.string).to eq <<-eos
+    expected_string = <<-eos
 name example.com
 id 6918990
 status active
@@ -229,6 +226,39 @@ image 6918990
 size 512mb
 backups_active false
       eos
+
+    cli.options = cli.options.merge(name: 'example.com', porcelain: true)
+    expect { cli.info }.to output(expected_string).to_stdout
+  end
+
+  it 'throws an error if no id or name provided when using porcelain' do
+    stub_request(:get, 'https://api.digitalocean.com/v2/droplets?page=1&per_page=1').
+      with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
+      to_return(status: 200, body: fixture('show_droplets'), headers: {})
+
+    stub_request(:get, 'https://api.digitalocean.com/v2/droplets?page=1&per_page=200').
+      with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
+      to_return(status: 200, body: fixture('show_droplets'), headers: {})
+
+    stub_request(:get, 'https://api.digitalocean.com/v2/droplets/6918990?per_page=200').
+      with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
+      to_return(status: 200, body: fixture('show_droplet'), headers: {})
+
+    expected_string = <<-eos
+name example.com
+id 6918990
+status active
+ip4 104.131.186.241
+ip6 2604:A880:0800:0010:0000:0000:031D:2001
+region nyc3
+image 6918990
+size 512mb
+backups_active false
+      eos
+
+    cli.options = cli.options.merge(porcelain: true)
+
+    expect { cli.info('example.com') }.to raise_error(SystemExit).and output(/Tugboat expects an exact droplet ID or droplet name for porcelain mode/).to_stdout
   end
 
   it 'shows a droplet attribute with an id' do
@@ -240,13 +270,13 @@ backups_active false
       with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
       to_return(status: 200, body: fixture('show_droplet'), headers: {})
 
-    cli.options = cli.options.merge(id: '6918990', attribute: 'ip4')
-    cli.info
-
-    expect($stdout.string).to eq <<-eos
+    expected_string = <<-eos
 Droplet id provided. Finding Droplet...done\e[0m, 6918990 (example.com)
 104.131.186.241
     eos
+
+    cli.options = cli.options.merge(id: '6918990', attribute: 'ip4')
+    expect { cli.info }.to output(expected_string).to_stdout
   end
 
   it 'shows a droplet attribute with a name' do
@@ -262,13 +292,13 @@ Droplet id provided. Finding Droplet...done\e[0m, 6918990 (example.com)
       with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
       to_return(status: 200, body: fixture('show_droplet'), headers: {})
 
-    cli.options = cli.options.merge(name: 'example.com', attribute: 'ip4')
-    cli.info
-
-    expect($stdout.string).to eq <<-eos
+    expected_string = <<-eos
 Droplet name provided. Finding droplet ID...done\e[0m, 6918990 (example.com)
 104.131.186.241
     eos
+
+    cli.options = cli.options.merge(name: 'example.com', attribute: 'ip4')
+    expect { cli.info }.to output(expected_string).to_stdout
   end
 
   it 'gives error if invalid attribute given' do
@@ -280,10 +310,7 @@ Droplet name provided. Finding droplet ID...done\e[0m, 6918990 (example.com)
       with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
       to_return(status: 200, body: fixture('show_droplet'), headers: {})
 
-    cli.options = cli.options.merge(id: 6_918_990, porcelain: true, attribute: 'foo')
-    expect { cli.info }.to raise_error(SystemExit)
-
-    expect($stdout.string).to eq <<-eos
+    expected_string = <<-eos
 Invalid attribute "foo"
 Provide one of the following:
     name
@@ -297,6 +324,9 @@ Provide one of the following:
     size
     backups_active
       eos
+
+    cli.options = cli.options.merge(id: 6_918_990, porcelain: true, attribute: 'foo')
+    expect { expect { cli.info }.to raise_error(SystemExit) }.to output(expected_string).to_stdout
   end
 
   it 'shows a droplet attribute with an id under porcelain mode' do
@@ -304,12 +334,12 @@ Provide one of the following:
       with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
       to_return(status: 200, body: fixture('show_droplet'), headers: {})
 
-    cli.options = cli.options.merge(id: '6918990', porcelain: true, attribute: 'ip4')
-    cli.info
-
-    expect($stdout.string).to eq <<-eos
+    expected_string = <<-eos
 104.131.186.241
-      eos
+    eos
+
+    cli.options = cli.options.merge(id: '6918990', porcelain: true, attribute: 'ip4')
+    expect { cli.info }.to output(expected_string).to_stdout
   end
 
   it 'shows a droplet attribute with a name under porcelain mode' do
@@ -325,11 +355,63 @@ Provide one of the following:
       with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
       to_return(status: 200, body: fixture('show_droplet'), headers: {})
 
-    cli.options = cli.options.merge(name: 'example.com', porcelain: true, attribute: 'ip4')
-    cli.info
-
-    expect($stdout.string).to eq <<-eos
+    expected_string = <<-eos
 104.131.186.241
     eos
+
+    cli.options = cli.options.merge(name: 'example.com', porcelain: true, attribute: 'ip4')
+    expect { cli.info }.to output(expected_string).to_stdout
+  end
+
+  it 'shows a droplet without a network not ready yet' do
+    stub_request(:get, 'https://api.digitalocean.com/v2/droplets?page=1&per_page=1').
+        with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
+        to_return(status: 200, body: fixture('show_droplets'), headers: {})
+
+    stub_request(:get, 'https://api.digitalocean.com/v2/droplets/6918990?per_page=200').
+        with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
+        to_return(status: 200, body: fixture('droplet_no_network'), headers: {})
+
+    expected_string = <<-eos
+Droplet id provided. Finding Droplet...done\e[0m, 6918990 (example.com)
+
+Name:             example.com
+ID:               6918990
+Status:           \e[32mactive\e[0m
+Region:           London 1 - lon1
+Image:            13089493 - ubuntu-14-04-x64
+Size:             512MB
+Backups Active:   false
+      eos
+
+    cli.options = cli.options.merge(id: 6_918_990)
+    expect { cli.info }.to output(expected_string).to_stdout
+  end
+
+  it 'shows a droplet that is inactive' do
+    stub_request(:get, 'https://api.digitalocean.com/v2/droplets?page=1&per_page=1').
+        with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
+        to_return(status: 200, body: fixture('show_droplets'), headers: {})
+
+    stub_request(:get, 'https://api.digitalocean.com/v2/droplets/3164494?per_page=200').
+        with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
+        to_return(headers: { 'Content-Type' => 'application/json' }, status: 200, body: fixture('show_droplet_inactive'))
+
+    expected_string = <<-eos
+Droplet id provided. Finding Droplet...done\e[0m, 3164494 (example.com)
+
+Name:             example.com
+ID:               3164494
+Status:           \e[31moff\e[0m
+IP4:              104.131.186.241
+IP6:              2604:A880:0800:0010:0000:0000:031D:2001
+Region:           New York 3 - nyc3
+Image:            6918990 - ubuntu-14-04-x64
+Size:             512MB
+Backups Active:   false
+      eos
+
+    cli.options = cli.options.merge(id: 3164494)
+    expect { cli.info }.to output(expected_string).to_stdout
   end
 end

--- a/spec/cli/info_image_cli_spec.rb
+++ b/spec/cli/info_image_cli_spec.rb
@@ -13,9 +13,7 @@ describe Tugboat::CLI do
         with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
         to_return(headers: { 'Content-Type' => 'application/json' }, status: 200, body: fixture('show_coreos_image'))
 
-      cli.info_image('745.1.0 (alpha)')
-
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Image fuzzy name provided. Finding image ID...done\e[0m, 12789325 (745.1.0 (alpha))
 
 Name:             745.1.0 (alpha)
@@ -24,6 +22,8 @@ Distribution:     CoreOS
 Min Disk Size:    20GB
 Regions:          nyc1,sfo1,nyc2,ams2,sgp1,lon1,nyc3,ams3,fra1
       eos
+
+      expect { cli.info_image('745.1.0 (alpha)') }.to output(expected_string).to_stdout
     end
 
     it 'shows an image with an id' do
@@ -35,10 +35,7 @@ Regions:          nyc1,sfo1,nyc2,ams2,sgp1,lon1,nyc3,ams3,fra1
         with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
         to_return(headers: { 'Content-Type' => 'application/json' }, status: 200, body: fixture('show_redmine_image'))
 
-      cli.options = cli.options.merge(id: 12_438_838)
-      cli.info_image
-
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Image id provided. Finding Image...done\e[0m, 12438838 (Redmine on 14.04)
 
 Name:             Redmine on 14.04
@@ -47,6 +44,9 @@ Distribution:     Ubuntu
 Min Disk Size:    20GB
 Regions:          nyc1,ams1,sfo1,nyc2,ams2,sgp1,lon1,nyc3,ams3,fra1
       eos
+
+      cli.options = cli.options.merge(id: 12_438_838)
+      expect { cli.info_image }.to output(expected_string).to_stdout
     end
 
     it 'shows an image with a name' do
@@ -58,10 +58,7 @@ Regions:          nyc1,ams1,sfo1,nyc2,ams2,sgp1,lon1,nyc3,ams3,fra1
         with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
         to_return(headers: { 'Content-Type' => 'application/json' }, status: 200, body: fixture('show_redmine_image'))
 
-      cli.options = cli.options.merge(name: 'Redmine on 14.04')
-      cli.info_image
-
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Image name provided. Finding Image...done\e[0m, 12438838 (Redmine on 14.04)
 
 Name:             Redmine on 14.04
@@ -70,6 +67,9 @@ Distribution:     Ubuntu
 Min Disk Size:    20GB
 Regions:          nyc1,ams1,sfo1,nyc2,ams2,sgp1,lon1,nyc3,ams3,fra1
       eos
+
+      cli.options = cli.options.merge(name: 'Redmine on 14.04')
+      expect { cli.info_image }.to output(expected_string).to_stdout
     end
 
     it 'errors if no image with matching id is found' do
@@ -81,12 +81,12 @@ Regions:          nyc1,ams1,sfo1,nyc2,ams2,sgp1,lon1,nyc3,ams3,fra1
         with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
         to_return(status: 404, body: fixture('not_found'), headers: {})
 
-      cli.options = cli.options.merge(id: '123')
-      expect { cli.info_image }.to raise_error(SystemExit)
-
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Image id provided. Finding Image...Failed to find Image: The resource you were accessing could not be found.
       eos
+
+      cli.options = cli.options.merge(id: '123')
+      expect { cli.info_image }.to raise_error(SystemExit).and output(expected_string).to_stdout
     end
 
     it 'errors if no image with matching name is found' do
@@ -95,12 +95,13 @@ Image id provided. Finding Image...Failed to find Image: The resource you were a
         to_return(headers: { 'Content-Type' => 'application/json' }, status: 200, body: fixture('show_images'))
 
       cli.options = cli.options.merge(name: 'foobarbaz')
-      expect { cli.info_image }.to raise_error(SystemExit)
 
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Image name provided. Finding Image...error
 Unable to find an image named 'foobarbaz'.
       eos
+
+      expect { cli.info_image }.to raise_error(SystemExit).and output(expected_string).to_stdout
     end
 
     it 'errors if no image with matching fuzzy name is found' do
@@ -108,12 +109,12 @@ Unable to find an image named 'foobarbaz'.
         with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
         to_return(headers: { 'Content-Type' => 'application/json' }, status: 200, body: fixture('show_images'))
 
-      expect { cli.info_image('foobarbaz') }.to raise_error(SystemExit)
-
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Image fuzzy name provided. Finding image ID...error
 Unable to find an image named 'foobarbaz'.
       eos
+
+      expect { cli.info_image('foobarbaz') }.to raise_error(SystemExit).and output(expected_string).to_stdout
     end
 
     it 'allows choice of multiple images' do
@@ -127,9 +128,7 @@ Unable to find an image named 'foobarbaz'.
 
       expect($stdin).to receive(:gets).and_return('0')
 
-      cli.info_image('ubun')
-
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Image fuzzy name provided. Finding image ID...Multiple images found.
 
 0) 14.10 x32 (9801951)
@@ -148,6 +147,8 @@ Distribution:     Ubuntu
 Min Disk Size:    20GB
 Regions:          nyc1,ams1,sfo1,nyc2,ams2,sgp1,lon1,nyc3,ams3,fra1
       eos
+
+      expect { cli.info_image('ubun') }.to output(expected_string).to_stdout
     end
   end
 end

--- a/spec/cli/keys_cli_spec.rb
+++ b/spec/cli/keys_cli_spec.rb
@@ -9,13 +9,13 @@ describe Tugboat::CLI do
         with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
         to_return(status: 200, body: fixture('show_keys'), headers: {})
 
-      cli.keys
-
-      expect($stdout.string).to eq <<-eos
+      expected_string =   <<-eos
 SSH Keys:
 Name: My SSH Public Key, (id: 512189), fingerprint: 3b:16:bf:e4:8b:00:8b:b8:59:8c:a9:d3:f0:19:45:fa
 Name: My Other SSH Public Key, (id: 512110), fingerprint: 3b:16:bf:d4:8b:00:8b:b8:59:8c:a9:d3:f0:19:45:fa
       eos
+
+      expect { cli.keys }.to output(expected_string).to_stdout
 
       expect(a_request(:get, 'https://api.digitalocean.com/v2/account/keys?per_page=200')).to have_been_made
     end

--- a/spec/cli/password_reset_cli_spec.rb
+++ b/spec/cli/password_reset_cli_spec.rb
@@ -18,13 +18,13 @@ describe Tugboat::CLI do
              headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
         to_return(status: 200, body: fixture('password_reset_response'), headers: {})
 
-      cli.password_reset('example.com')
-
-      expect($stdout.string).to eq <<-eos
+      expected_string =   <<-eos
 Droplet fuzzy name provided. Finding droplet ID...done\e[0m, 6918990 (example.com)
 Queuing password reset for 6918990 (example.com)...Password reset successful!
 Your new root password will be emailed to you
       eos
+
+      expect { cli.password_reset('example.com') }.to output(expected_string).to_stdout
     end
 
     it 'resets the root password given an id' do
@@ -45,14 +45,14 @@ Your new root password will be emailed to you
              headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
         to_return(status: 200, body: fixture('password_reset_response'), headers: {})
 
-      cli.options = cli.options.merge(id: 6_918_990)
-      cli.password_reset
-
-      expect($stdout.string).to eq <<-eos
+      expected_string =   <<-eos
 Droplet id provided. Finding Droplet...done\e[0m, 6918990 (example.com)
 Queuing password reset for 6918990 (example.com)...Password reset successful!
 Your new root password will be emailed to you
       eos
+
+      cli.options = cli.options.merge(id: 6_918_990)
+      expect { cli.password_reset }.to output(expected_string).to_stdout
     end
 
     it 'resets the root password given a name' do
@@ -69,14 +69,14 @@ Your new root password will be emailed to you
              headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
         to_return(status: 200, body: fixture('password_reset_response'), headers: {})
 
-      cli.options = cli.options.merge(name: 'example.com')
-      cli.password_reset
-
-      expect($stdout.string).to eq <<-eos
+      expected_string =   <<-eos
 Droplet name provided. Finding droplet ID...done\e[0m, 6918990 (example.com)
 Queuing password reset for 6918990 (example.com)...Password reset successful!
 Your new root password will be emailed to you
       eos
+
+      cli.options = cli.options.merge(name: 'example.com')
+      expect { cli.password_reset }.to output(expected_string).to_stdout
     end
 
     it 'raises SystemExit when a request fails' do
@@ -95,7 +95,7 @@ Your new root password will be emailed to you
 
       cli.options = cli.options.merge(name: 'example.com')
 
-      expect { cli.password_reset('example.com') }.to raise_error(SystemExit)
+      expect { cli.password_reset('example.com') }.to raise_error(SystemExit).and output(%r{Failed to reset password on Droplet: Some error}).to_stdout
     end
   end
 end

--- a/spec/cli/rebuild_cli_spec.rb
+++ b/spec/cli/rebuild_cli_spec.rb
@@ -24,13 +24,13 @@ describe Tugboat::CLI do
 
       expect($stdin).to receive(:gets).and_return('y')
 
-      cli.rebuild('example.com', 'ubuntu-14-04-x64')
-
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Droplet fuzzy name provided. Finding droplet ID...done\e[0m, 6918990 (example.com)
 Image fuzzy name provided. Finding image ID...done\e[0m, 12790328 (14.04 x64)
 Warning! Potentially destructive action. Please confirm [y/n]: Queuing rebuild for droplet 6918990 (example.com) with image 12790328 (14.04 x64)...Rebuild complete
       eos
+
+      expect { cli.rebuild('example.com', 'ubuntu-14-04-x64') }.to output(expected_string).to_stdout
     end
 
     it 'rebuilds a droplet with an id based on an image with a fuzzy name' do
@@ -54,13 +54,14 @@ Warning! Potentially destructive action. Please confirm [y/n]: Queuing rebuild f
       expect($stdin).to receive(:gets).and_return('y')
 
       cli.options = cli.options.merge(id: '12790328')
-      cli.rebuild('example.com', 'ubuntu-14-04-x64')
 
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Droplet id provided. Finding Droplet...done\e[0m, 6918990 (example.com)
 Image fuzzy name provided. Finding image ID...done\e[0m, 12790328 (14.04 x64)
 Warning! Potentially destructive action. Please confirm [y/n]: Queuing rebuild for droplet 6918990 (example.com) with image 12790328 (14.04 x64)...Rebuild complete
       eos
+
+      expect { cli.rebuild('example.com', 'ubuntu-14-04-x64') }.to output(expected_string).to_stdout
     end
 
     it 'rebuilds a droplet with a name based on an image with a fuzzy name' do
@@ -88,13 +89,14 @@ Warning! Potentially destructive action. Please confirm [y/n]: Queuing rebuild f
       expect($stdin).to receive(:gets).and_return('y')
 
       cli.options = cli.options.merge(name: 'example.com')
-      cli.rebuild('example.com', 'ubuntu-14-04-x64')
 
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Droplet name provided. Finding droplet ID...done\e[0m, 6918990 (example.com)
 Image fuzzy name provided. Finding image ID...done\e[0m, 12790328 (14.04 x64)
 Warning! Potentially destructive action. Please confirm [y/n]: Queuing rebuild for droplet 6918990 (example.com) with image 12790328 (14.04 x64)...Rebuild complete
       eos
+
+      expect { cli.rebuild('example.com', 'ubuntu-14-04-x64') }.to output(expected_string).to_stdout
     end
 
     it 'rebuilds a droplet with a fuzzy name based on an image with an id' do
@@ -125,14 +127,14 @@ Warning! Potentially destructive action. Please confirm [y/n]: Queuing rebuild f
 
       expect($stdin).to receive(:gets).and_return('y')
 
-      cli.options = cli.options.merge(image_id: 12_790_328)
-      cli.rebuild('example.com', 'ubuntu-14-04-x64')
-
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Droplet fuzzy name provided. Finding droplet ID...done\e[0m, 6918990 (example.com)
 Image id provided. Finding Image...done\e[0m, 6376601 (My application image)
 Warning! Potentially destructive action. Please confirm [y/n]: Queuing rebuild for droplet 6918990 (example.com) with image 6376601 (My application image)...Rebuild complete
       eos
+
+      cli.options = cli.options.merge(image_id: 12_790_328)
+      expect { cli.rebuild('example.com', 'ubuntu-14-04-x64') }.to output(expected_string).to_stdout
     end
 
     it 'rebuilds a droplet with an id based on an image with an id' do
@@ -164,13 +166,14 @@ Warning! Potentially destructive action. Please confirm [y/n]: Queuing rebuild f
       expect($stdin).to receive(:gets).and_return('y')
 
       cli.options = cli.options.merge(id: '12790328', image_id: 12_790_328)
-      cli.rebuild('example.com', 'ubuntu-14-04-x64')
 
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Droplet id provided. Finding Droplet...done\e[0m, 6918990 (example.com)
 Image id provided. Finding Image...done\e[0m, 6376601 (My application image)
 Warning! Potentially destructive action. Please confirm [y/n]: Queuing rebuild for droplet 6918990 (example.com) with image 6376601 (My application image)...Rebuild complete
       eos
+
+      expect { cli.rebuild('example.com', 'ubuntu-14-04-x64') }.to output(expected_string).to_stdout
     end
 
     it 'rebuilds a droplet with a name based on an image with an id' do
@@ -202,13 +205,14 @@ Warning! Potentially destructive action. Please confirm [y/n]: Queuing rebuild f
       expect($stdin).to receive(:gets).and_return('y')
 
       cli.options = cli.options.merge(name: 'example.com', image_id: 12_790_328)
-      cli.rebuild('example.com', 'ubuntu-14-04-x64')
 
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Droplet name provided. Finding droplet ID...done\e[0m, 6918990 (example.com)
 Image id provided. Finding Image...done\e[0m, 6376601 (My application image)
 Warning! Potentially destructive action. Please confirm [y/n]: Queuing rebuild for droplet 6918990 (example.com) with image 6376601 (My application image)...Rebuild complete
       eos
+
+      expect { cli.rebuild('example.com', 'ubuntu-14-04-x64') }.to output(expected_string).to_stdout
     end
 
     it 'rebuilds a droplet with a fuzzy name based on an image with a name' do
@@ -233,13 +237,13 @@ Warning! Potentially destructive action. Please confirm [y/n]: Queuing rebuild f
 
       cli.options = cli.options.merge(image_name: '14.04 x64')
 
-      cli.rebuild('example.com', 'ubuntu-14-04-x64')
-
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Droplet fuzzy name provided. Finding droplet ID...done\e[0m, 6918990 (example.com)
 Image name provided. Finding Image...done\e[0m, 12790328 (14.04 x64)
 Warning! Potentially destructive action. Please confirm [y/n]: Queuing rebuild for droplet 6918990 (example.com) with image 12790328 (14.04 x64)...Rebuild complete
       eos
+
+      expect { cli.rebuild('example.com', 'ubuntu-14-04-x64') }.to output(expected_string).to_stdout
     end
 
     it 'rebuilds a droplet with an id based on an image with a name' do
@@ -267,13 +271,14 @@ Warning! Potentially destructive action. Please confirm [y/n]: Queuing rebuild f
       expect($stdin).to receive(:gets).and_return('y')
 
       cli.options = cli.options.merge(id: '12790328', image_name: '14.04 x64')
-      cli.rebuild('example.com', '14.04 x64')
 
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Droplet id provided. Finding Droplet...done\e[0m, 6918990 (example.com)
 Image name provided. Finding Image...done\e[0m, 12790328 (14.04 x64)
 Warning! Potentially destructive action. Please confirm [y/n]: Queuing rebuild for droplet 6918990 (example.com) with image 12790328 (14.04 x64)...Rebuild complete
       eos
+
+      expect { cli.rebuild('example.com', '14.04 x64') }.to output(expected_string).to_stdout
     end
 
     it 'rebuilds a droplet with a name based on an image with a name' do
@@ -297,13 +302,14 @@ Warning! Potentially destructive action. Please confirm [y/n]: Queuing rebuild f
       expect($stdin).to receive(:gets).and_return('y')
 
       cli.options = cli.options.merge(name: 'example.com', image_name: '14.04 x64')
-      cli.rebuild('example.com', '14.04 x64')
 
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Droplet name provided. Finding droplet ID...done\e[0m, 6918990 (example.com)
 Image name provided. Finding Image...done\e[0m, 12790328 (14.04 x64)
 Warning! Potentially destructive action. Please confirm [y/n]: Queuing rebuild for droplet 6918990 (example.com) with image 12790328 (14.04 x64)...Rebuild complete
       eos
+
+      expect { cli.rebuild('example.com', '14.04 x64') }.to output(expected_string).to_stdout
     end
 
     it 'rebuilds a droplet with confirm flag set' do
@@ -325,13 +331,14 @@ Warning! Potentially destructive action. Please confirm [y/n]: Queuing rebuild f
         to_return(status: 200, body: '', headers: {})
 
       cli.options = cli.options.merge(confirm: 'no')
-      cli.rebuild('example.com', '14.04 x64')
 
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Droplet fuzzy name provided. Finding droplet ID...done\e[0m, 6918990 (example.com)
 Image fuzzy name provided. Finding image ID...done\e[0m, 12790328 (14.04 x64)
 Queuing rebuild for droplet 6918990 (example.com) with image 12790328 (14.04 x64)...Rebuild complete
       eos
+
+      expect { cli.rebuild('example.com', '14.04 x64') }.to output(expected_string).to_stdout
     end
   end
 end

--- a/spec/cli/regions_cli_spec.rb
+++ b/spec/cli/regions_cli_spec.rb
@@ -9,9 +9,7 @@ describe Tugboat::CLI do
         with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
         to_return(status: 200, body: fixture('show_regions'), headers: { 'Content-Type' => 'application/json' })
 
-      cli.regions
-
-      expect($stdout.string).to eq <<-eos
+      expected_string =   <<-eos
 Regions:
 Amsterdam 1 (slug: ams1)
 Amsterdam 2 (slug: ams2)
@@ -23,6 +21,8 @@ New York 3 (slug: nyc3)
 San Francisco 1 (slug: sfo1)
 Singapore 1 (slug: sgp1)
       eos
+
+      expect { cli.regions }.to output(expected_string).to_stdout
 
       expect(a_request(:get, 'https://api.digitalocean.com/v2/regions?page=1&per_page=20')).
         to have_been_made

--- a/spec/cli/resize_cli_spec.rb
+++ b/spec/cli/resize_cli_spec.rb
@@ -18,13 +18,13 @@ describe Tugboat::CLI do
              headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
         to_return(status: 200, body: fixture('resize_droplet'), headers: {})
 
-      cli.options = cli.options.merge(size: '1gb')
-      cli.resize('example.com')
-
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Droplet fuzzy name provided. Finding droplet ID...done\e[0m, 6918990 (example.com)
 Queuing resize for 6918990 (example.com)...Resize complete!
       eos
+
+      cli.options = cli.options.merge(size: '1gb')
+      expect { cli.resize('example.com') }.to output(expected_string).to_stdout
     end
 
     it 'resizes a droplet with an id' do
@@ -41,13 +41,13 @@ Queuing resize for 6918990 (example.com)...Resize complete!
              headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
         to_return(status: 200, body: fixture('resize_droplet'), headers: {})
 
-      cli.options = cli.options.merge(size: '1gb', id: 6_918_990)
-      cli.resize
-
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Droplet id provided. Finding Droplet...done\e[0m, 6918990 (example.com)
 Queuing resize for 6918990 (example.com)...Resize complete!
       eos
+
+      cli.options = cli.options.merge(size: '1gb', id: 6_918_990)
+      expect { cli.resize }.to output(expected_string).to_stdout
     end
 
     it 'resizes a droplet with a name' do
@@ -64,13 +64,13 @@ Queuing resize for 6918990 (example.com)...Resize complete!
              headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
         to_return(status: 200, body: fixture('resize_droplet'), headers: {})
 
-      cli.options = cli.options.merge(size: '1gb', name: 'example.com')
-      cli.resize
-
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Droplet name provided. Finding droplet ID...done\e[0m, 6918990 (example.com)
 Queuing resize for 6918990 (example.com)...Resize complete!
       eos
+
+      cli.options = cli.options.merge(size: '1gb', name: 'example.com')
+      expect { cli.resize }.to output(expected_string).to_stdout
     end
 
     it 'raises SystemExit when a request fails' do
@@ -87,13 +87,13 @@ Queuing resize for 6918990 (example.com)...Resize complete!
              headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
         to_return(headers: { 'Content-Type' => 'application/json' }, status: 500, body: '{"status":"ERROR","message":"Some error"}')
 
-      cli.options = cli.options.merge(size: '1gb')
-      expect { cli.resize('example.com') }.to raise_error(SystemExit)
-
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Droplet fuzzy name provided. Finding droplet ID...done\e[0m, 6918990 (example.com)
 Queuing resize for 6918990 (example.com)...Failed to resize Droplet: Some error
       eos
+
+      cli.options = cli.options.merge(size: '1gb')
+      expect { cli.resize('example.com') }.to raise_error(SystemExit).and output(expected_string).to_stdout
     end
   end
 end

--- a/spec/cli/restart_cli_spec.rb
+++ b/spec/cli/restart_cli_spec.rb
@@ -18,12 +18,12 @@ describe Tugboat::CLI do
              headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
         to_return(status: 200, body: fixture('restart_response'), headers: {})
 
-      cli.restart('example.com')
-
-      expect($stdout.string).to eq <<-eos
+      expected_string =   <<-eos
 Droplet fuzzy name provided. Finding droplet ID...done\e[0m, 6918990 (example.com)
 Queuing restart for 6918990 (example.com)...Restart complete!
       eos
+
+      expect { cli.restart('example.com') }.to output(expected_string).to_stdout
     end
 
     it 'restarts a droplet hard when the hard option is used' do
@@ -41,12 +41,13 @@ Queuing restart for 6918990 (example.com)...Restart complete!
         to_return(status: 200, body: '', headers: {})
 
       cli.options = cli.options.merge(hard: true)
-      cli.restart('example.com')
 
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Droplet fuzzy name provided. Finding droplet ID...done\e[0m, 6918990 (example.com)
 Queuing hard restart for 6918990 (example.com)...Restart complete!
       eos
+
+      expect { cli.restart('example.com') }.to output(expected_string).to_stdout
     end
 
     it 'with an id' do
@@ -64,12 +65,13 @@ Queuing hard restart for 6918990 (example.com)...Restart complete!
         to_return(status: 200, body: fixture('restart_response'), headers: {})
 
       cli.options = cli.options.merge(id: '6918990')
-      cli.restart
 
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Droplet id provided. Finding Droplet...done\e[0m, 6918990 (example.com)
 Queuing restart for 6918990 (example.com)...Restart complete!
       eos
+
+      expect { cli.restart }.to output(expected_string).to_stdout
     end
 
     it 'with a name' do
@@ -86,13 +88,32 @@ Queuing restart for 6918990 (example.com)...Restart complete!
              headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
         to_return(status: 200, body: fixture('restart_response'), headers: {})
 
-      cli.options = cli.options.merge(name: 'example.com')
-      cli.restart
-
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Droplet name provided. Finding droplet ID...done\e[0m, 6918990 (example.com)
 Queuing restart for 6918990 (example.com)...Restart complete!
       eos
+
+      cli.options = cli.options.merge(name: 'example.com')
+      expect { cli.restart }.to output(expected_string).to_stdout
+    end
+
+    it 'raises SystemExit when a request fails' do
+      stub_request(:get, 'https://api.digitalocean.com/v2/droplets?page=1&per_page=1').
+        with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
+        to_return(status: 200, body: fixture('show_droplets'), headers: {})
+
+      stub_request(:get, 'https://api.digitalocean.com/v2/droplets?page=1&per_page=200').
+        with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
+        to_return(status: 200, body: fixture('show_droplets'), headers: { 'Content-Type' => 'application/json' })
+
+      stub_request(:post, 'https://api.digitalocean.com/v2/droplets/6918990/actions').
+        with(body: '{"type":"reboot"}',
+             headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
+        to_return(headers: { 'Content-Type' => 'application/json' }, status: 500, body: '{"status":"ERROR","message":"Some error"}')
+
+      cli.options = cli.options.merge(name: 'example.com')
+
+      expect { cli.restart }.to raise_error(SystemExit).and output(%r{Failed to restart Droplet: Some error}).to_stdout
     end
   end
 end

--- a/spec/cli/sizes_cli_spec.rb
+++ b/spec/cli/sizes_cli_spec.rb
@@ -9,9 +9,7 @@ describe Tugboat::CLI do
         with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
         to_return(headers: { 'Content-Type' => 'application/json' }, status: 200, body: fixture('show_sizes'))
 
-      cli.sizes
-
-      expect($stdout.string).to eq <<-eos
+      cli_sizes_output = <<-eos
 Sizes:
 Disk: 20GB, Memory: 512MB (slug: 512mb)
 Disk: 30GB, Memory: 1024MB (slug: 1gb)
@@ -23,6 +21,8 @@ Disk: 320GB, Memory: 32768MB (slug: 32gb)
 Disk: 480GB, Memory: 49152MB (slug: 48gb)
 Disk: 640GB, Memory: 65536MB (slug: 64gb)
       eos
+
+      expect { cli.sizes }.to output(cli_sizes_output).to_stdout
     end
   end
 end

--- a/spec/cli/snapshot_cli_spec.rb
+++ b/spec/cli/snapshot_cli_spec.rb
@@ -20,13 +20,13 @@ describe Tugboat::CLI do
              headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
         to_return(status: 200, body: fixture('snapshot_response'), headers: {})
 
-      cli.snapshot(snapshot_name, 'example3.com')
-
-      expect($stdout.string).to eq <<-eos
+      snapshot_fuzzy_stdout = <<-eos
 Droplet fuzzy name provided. Finding droplet ID...done\e[0m, 3164444 (example3.com)
 Warning: Droplet must be in a powered off state for snapshot to be successful
 Queuing snapshot 'foo-snapshot' for 3164444 (example3.com)...Snapshot successful!
       eos
+
+      expect { cli.snapshot(snapshot_name, 'example3.com') }.to output(snapshot_fuzzy_stdout).to_stdout
     end
 
     it 'with an id' do
@@ -44,13 +44,14 @@ Queuing snapshot 'foo-snapshot' for 3164444 (example3.com)...Snapshot successful
         to_return(status: 200, body: fixture('snapshot_response'), headers: {})
 
       cli.options = cli.options.merge(id: '3164444')
-      cli.snapshot(snapshot_name)
 
-      expect($stdout.string).to eq <<-eos
+      snapshot_id_stdout = <<-eos
 Droplet id provided. Finding Droplet...done\e[0m, 3164494 (example.com)
 Warning: Droplet must be in a powered off state for snapshot to be successful
 Queuing snapshot 'foo-snapshot' for 3164494 (example.com)...Snapshot successful!
       eos
+
+      expect { cli.snapshot(snapshot_name) }.to output(snapshot_id_stdout).to_stdout
     end
 
     it 'with a name' do
@@ -68,13 +69,14 @@ Queuing snapshot 'foo-snapshot' for 3164494 (example.com)...Snapshot successful!
         to_return(status: 200, body: fixture('snapshot_response'), headers: {})
 
       cli.options = cli.options.merge(name: 'example3.com')
-      cli.snapshot(snapshot_name)
 
-      expect($stdout.string).to eq <<-eos
+      snapshot_name_stdout = <<-eos
 Droplet name provided. Finding droplet ID...done\e[0m, 3164444 (example3.com)
 Warning: Droplet must be in a powered off state for snapshot to be successful
 Queuing snapshot 'foo-snapshot' for 3164444 (example3.com)...Snapshot successful!
       eos
+
+      expect { cli.snapshot(snapshot_name) }.to output(snapshot_name_stdout).to_stdout
     end
 
     it 'does not snapshot a droplet that is active' do
@@ -87,12 +89,13 @@ Queuing snapshot 'foo-snapshot' for 3164444 (example3.com)...Snapshot successful
         to_return(status: 200, body: fixture('show_droplets'), headers: {})
 
       cli.options = cli.options.merge(name: 'example.com')
-      expect { cli.snapshot(snapshot_name) }.to raise_error(SystemExit)
 
-      expect($stdout.string).to eq <<-eos
+      snapshot_active_error_stdout = <<-eos
 Droplet name provided. Finding droplet ID...done\e[0m, 6918990 (example.com)
 Droplet must be off for this operation to be successful.
       eos
+
+      expect { cli.snapshot(snapshot_name) }.to raise_error(SystemExit).and output(snapshot_active_error_stdout).to_stdout
     end
   end
 end

--- a/spec/cli/ssh_cli_spec.rb
+++ b/spec/cli/ssh_cli_spec.rb
@@ -13,7 +13,7 @@ describe Tugboat::CLI do
         to_return(headers: { 'Content-Type' => 'application/json' }, status: 200, body: fixture('show_droplets'))
       allow(Kernel).to receive(:exec).with('ssh', anything, anything, anything, anything, anything, anything, anything, anything, anything, anything, anything, anything, anything)
 
-      cli.ssh('example.com')
+      expect { cli.ssh('example.com') }.to output(%r{Attempting SSH: baz@104.236.32.182}).to_stdout
     end
 
     it "wait's until droplet active if -w command is given and droplet already active" do
@@ -31,9 +31,7 @@ describe Tugboat::CLI do
 
       cli.options = cli.options.merge(wait: true)
 
-      cli.ssh('example.com')
-
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Droplet fuzzy name provided. Finding droplet ID...done\e[0m, 6918990 (example.com)
 Executing SSH on Droplet (example.com)...
 Wait flag given, waiting for droplet to become active
@@ -41,6 +39,8 @@ Wait flag given, waiting for droplet to become active
 Attempting SSH: baz@104.236.32.182
 SShing with options: -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -i #{Dir.home}/.ssh/id_rsa2 -p 33 baz@104.236.32.182
       eos
+
+      expect { cli.ssh('example.com') }.to output(expected_string).to_stdout
     end
 
     it "wait's until droplet active if -w command is given and droplet eventually active" do
@@ -61,9 +61,7 @@ SShing with options: -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownH
 
       cli.options = cli.options.merge(wait: true)
 
-      cli.ssh('example.com')
-
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Droplet fuzzy name provided. Finding droplet ID...done\e[0m, 6918990 (example.com)
 Executing SSH on Droplet (example.com)...
 Wait flag given, waiting for droplet to become active
@@ -71,6 +69,8 @@ Wait flag given, waiting for droplet to become active
 Attempting SSH: baz@104.236.32.182
 SShing with options: -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -i #{Dir.home}/.ssh/id_rsa2 -p 33 baz@104.236.32.182
       eos
+
+      expect { cli.ssh('example.com') }.to output(expected_string).to_stdout
     end
 
     it 'does not allow ssh into a droplet that is inactive' do
@@ -82,12 +82,12 @@ SShing with options: -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownH
         to_return(headers: { 'Content-Type' => 'application/json' }, status: 200, body: fixture('show_droplets'))
       allow(Kernel).to receive(:exec)
 
-      expect { cli.ssh('example3.com') }.to raise_error(SystemExit)
-
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Droplet fuzzy name provided. Finding droplet ID...done\e[0m, 3164444 (example3.com)
 Droplet must be on for this operation to be successful.
       eos
+
+      expect { expect { cli.ssh('example3.com') }.to raise_error(SystemExit) }.to output(expected_string).to_stdout
     end
   end
 end

--- a/spec/cli/start_cli_spec.rb
+++ b/spec/cli/start_cli_spec.rb
@@ -18,12 +18,12 @@ describe Tugboat::CLI do
              headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
         to_return(status: 200, body: fixture('droplet_start_response'), headers: {})
 
-      cli.start('example3.com')
-
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Droplet fuzzy name provided. Finding droplet ID...done\e[0m, 3164444 (example3.com)
 Queuing start for 3164444 (example3.com)...Start complete!
       eos
+
+      expect { cli.start('example3.com') }.to output(expected_string).to_stdout
     end
 
     it 'starts the droplet with an id' do
@@ -39,13 +39,13 @@ Queuing start for 3164444 (example3.com)...Start complete!
         with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
         to_return(headers: { 'Content-Type' => 'application/json' }, status: 200, body: fixture('show_droplet_inactive'))
 
-      cli.options = cli.options.merge(id: '3164494')
-      cli.start
-
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Droplet id provided. Finding Droplet...done\e[0m, 3164494 (example.com)
 Queuing start for 3164494 (example.com)...Start complete!
       eos
+
+      cli.options = cli.options.merge(id: '3164494')
+      expect { cli.start }.to output(expected_string).to_stdout
     end
 
     it 'starts the droplet with a name' do
@@ -62,13 +62,13 @@ Queuing start for 3164494 (example.com)...Start complete!
              headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
         to_return(status: 200, body: fixture('droplet_start_response'), headers: {})
 
-      cli.options = cli.options.merge(name: 'example3.com')
-      cli.start
-
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Droplet name provided. Finding droplet ID...done\e[0m, 3164444 (example3.com)
 Queuing start for 3164444 (example3.com)...Start complete!
       eos
+
+      cli.options = cli.options.merge(name: 'example3.com')
+      expect { cli.start }.to output(expected_string).to_stdout
     end
 
     it 'does not start a droplet that is inactive' do
@@ -80,13 +80,13 @@ Queuing start for 3164444 (example3.com)...Start complete!
         with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
         to_return(status: 200, body: fixture('show_droplets'), headers: {})
 
-      cli.options = cli.options.merge(name: 'example.com')
-      expect { cli.start }.to raise_error(SystemExit)
-
-      expect($stdout.string).to eq <<-eos
+      expected_string =  <<-eos
 Droplet name provided. Finding droplet ID...done\e[0m, 6918990 (example.com)
 Droplet must be off for this operation to be successful.
       eos
+
+      cli.options = cli.options.merge(name: 'example.com')
+      expect { cli.start }.to raise_error(SystemExit).and output(expected_string).to_stdout
     end
   end
 end

--- a/spec/cli/verify_cli_spec.rb
+++ b/spec/cli/verify_cli_spec.rb
@@ -9,8 +9,7 @@ describe Tugboat::CLI do
         with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
         to_return(status: 200, body: fixture('show_droplets'), headers: {})
 
-      cli.verify
-      expect($stdout.string).to eq "Authentication with DigitalOcean was successful.\n"
+      expect { cli.verify }.to output("Authentication with DigitalOcean was successful.\n").to_stdout
       expect(a_request(:get, 'https://api.digitalocean.com/v2/droplets?page=1&per_page=1')).to have_been_made
     end
 
@@ -19,8 +18,7 @@ describe Tugboat::CLI do
         with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
         to_return(headers: { 'Content-Type' => 'text/html' }, status: 401, body: fixture('401'))
 
-      expect { cli.verify }.to raise_error(SystemExit)
-      expect($stdout.string).to include 'Failed to connect to DigitalOcean. Reason given from API: unauthorized - Unable to authenticate you.'
+      expect { cli.verify }.to raise_error(SystemExit).and output(%r{Failed to connect to DigitalOcean. Reason given from API: unauthorized - Unable to authenticate you.}).to_stdout
       expect(a_request(:get, 'https://api.digitalocean.com/v2/droplets?page=1&per_page=1')).to have_been_made
     end
 
@@ -29,9 +27,8 @@ describe Tugboat::CLI do
         with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
         to_return(headers: { 'Content-Type' => 'text/html' }, status: 500, body: fixture('500', 'html'))
 
-      expect { cli.verify }.to raise_error(SystemExit)
-      expect($stdout.string).to include 'Authentication with DigitalOcean failed at an early stage'
-      expect($stdout.string).to include "<title>DigitalOcean - Seems we've encountered a problem!</title>"
+      expect { cli.verify }.to raise_error(SystemExit).and output(%r{<title>DigitalOcean - Seems we've encountered a problem!}).to_stdout
+
       # TODO: Make it so this doesnt barf up a huge HTML file...
       expect(a_request(:get, 'https://api.digitalocean.com/v2/droplets?page=1&per_page=1')).to have_been_made
     end

--- a/spec/cli/version_cli_spec.rb
+++ b/spec/cli/version_cli_spec.rb
@@ -6,9 +6,8 @@ describe Tugboat::CLI do
   describe 'version' do
     it 'shows the correct version' do
       cli.options = cli.options.merge(version: true)
-      cli.version
 
-      expect($stdout.string.chomp).to eq("Tugboat #{Tugboat::VERSION}")
+      expect { cli.version }.to output("Tugboat #{Tugboat::VERSION}\n").to_stdout
     end
   end
 end

--- a/spec/cli/wait_cli_spec.rb
+++ b/spec/cli/wait_cli_spec.rb
@@ -17,13 +17,13 @@ describe Tugboat::CLI do
         with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
         to_return(status: 200, body: fixture('show_droplet'), headers: {})
 
-      cli.options = cli.options.merge(state: 'active')
-      cli.wait('example.com')
-
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Droplet fuzzy name provided. Finding droplet ID...done\e[0m, 6918990 (example.com)
 Waiting for droplet to become active..done\e[0m (0s)
 eos
+
+      cli.options = cli.options.merge(state: 'active')
+      expect { cli.wait('example.com') }.to output(expected_string).to_stdout
     end
 
     it 'loops whilst it waits for state' do
@@ -42,13 +42,13 @@ eos
           status: 200, body: fixture('show_droplet'), headers: {}
         )
 
-      cli.options = cli.options.merge(state: 'active')
-      cli.wait('example.com')
-
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Droplet fuzzy name provided. Finding droplet ID...done\e[0m, 6918990 (example.com)
 Waiting for droplet to become active...done\e[0m (2s)
 eos
+
+      cli.options = cli.options.merge(state: 'active')
+      expect { cli.wait('example.com') }.to output(expected_string).to_stdout
     end
 
     it 'waits for a droplet with an id' do
@@ -60,13 +60,13 @@ eos
         with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
         to_return(status: 200, body: fixture('show_droplet'), headers: {})
 
-      cli.options = cli.options.merge(id: '6918990', state: 'active')
-      cli.wait
-
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Droplet id provided. Finding Droplet...done\e[0m, 6918990 (example.com)
 Waiting for droplet to become active..done\e[0m (0s)
       eos
+
+      cli.options = cli.options.merge(id: '6918990', state: 'active')
+      expect { cli.wait }.to output(expected_string).to_stdout
     end
 
     it 'waits for a droplet with a name' do
@@ -82,13 +82,13 @@ Waiting for droplet to become active..done\e[0m (0s)
         with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
         to_return(status: 200, body: fixture('show_droplet'), headers: {})
 
-      cli.options = cli.options.merge(name: 'example.com', state: 'active')
-      cli.wait
-
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Droplet name provided. Finding droplet ID...done\e[0m, 6918990 (example.com)
 Waiting for droplet to become active..done\e[0m (0s)
 eos
+
+      cli.options = cli.options.merge(name: 'example.com', state: 'active')
+      expect { cli.wait }.to output(expected_string).to_stdout
     end
   end
 end

--- a/spec/middleware/base_spec.rb
+++ b/spec/middleware/base_spec.rb
@@ -7,8 +7,7 @@ describe Tugboat::Middleware::Base do
 
   describe '.initialize' do
     it 'prints a clear line' do
-      expect($stdout).to receive(:print).with('')
-      klass.new({})
+      expect { klass.new({}) }.to output('').to_stdout
     end
   end
 end

--- a/spec/middleware/check_configuration_spec.rb
+++ b/spec/middleware/check_configuration_spec.rb
@@ -8,7 +8,7 @@ describe Tugboat::Middleware::CheckConfiguration do
       # Delete the temp configuration file.
       File.delete(project_path + '/tmp/tugboat')
 
-      expect { described_class.new(app).call(env) }.to raise_error(SystemExit)
+      expect { described_class.new(app).call(env) }.to raise_error(SystemExit).and output(%r{You must run `tugboat authorize` in order to connect to DigitalOcean}).to_stdout
     end
   end
 end

--- a/spec/middleware/check_credentials_spec.rb
+++ b/spec/middleware/check_credentials_spec.rb
@@ -12,7 +12,7 @@ describe Tugboat::Middleware::CheckCredentials do
       # Inject the client.
       env['barge'] = ocean
 
-      expect { described_class.new(app).call(env) }.to raise_error(SystemExit)
+      expect { described_class.new(app).call(env) }.to raise_error(SystemExit).and output(%r{Failed to connect to DigitalOcean. Reason given from API: unauthorized - Unable to authenticate you.}).to_stdout
       expect(a_request(:get, 'https://api.digitalocean.com/v2/droplets?page=1&per_page=1')).
         to have_been_made
     end

--- a/spec/middleware/check_droplet_active_spec.rb
+++ b/spec/middleware/check_droplet_active_spec.rb
@@ -7,7 +7,7 @@ describe Tugboat::Middleware::CheckDropletActive do
     it 'raises an error when droplet is not active' do
       env['droplet_status'] = 'off'
 
-      expect { described_class.new(app).call(env) }.to raise_error(SystemExit)
+      expect { described_class.new(app).call(env) }.to raise_error(SystemExit).and output(%r{Droplet must be on for this operation to be successful.}).to_stdout
     end
   end
 end

--- a/spec/middleware/check_droplet_inactive_spec.rb
+++ b/spec/middleware/check_droplet_inactive_spec.rb
@@ -7,7 +7,7 @@ describe Tugboat::Middleware::CheckDropletInactive do
     it 'raises an error when droplet is active' do
       env['droplet_status'] = 'active'
 
-      expect { described_class.new(app).call(env) }.to raise_error(SystemExit)
+      expect { described_class.new(app).call(env) }.to raise_error(SystemExit).and output(%r{Droplet must be off for this operation to be successful.}).to_stdout
     end
   end
 end

--- a/spec/middleware/find_droplet_spec.rb
+++ b/spec/middleware/find_droplet_spec.rb
@@ -5,11 +5,9 @@ describe Tugboat::Middleware::FindDroplet do
 
   describe '.call' do
     it 'raises SystemExit with no droplet data' do
-      expect { described_class.new(app).call(env) }.to raise_error(SystemExit)
-
-      expect($stdout.string).to include 'Tugboat attempted to find a droplet with no arguments'
-      expect($stdout.string).to include 'For more help run: '
-      expect($stdout.string).to include 'Try running `tugboat '
+      expect { described_class.new(app).call(env) }.to raise_error(SystemExit).and output(%r{Tugboat attempted to find a droplet with no argument}).to_stdout
+      expect { described_class.new(app).call(env) }.to raise_error(SystemExit).and output(%r{For more help run:}).to_stdout
+      expect { described_class.new(app).call(env) }.to raise_error(SystemExit).and output(%r{Try running `tugboat}).to_stdout
     end
   end
 end

--- a/spec/middleware/find_image_spec.rb
+++ b/spec/middleware/find_image_spec.rb
@@ -5,11 +5,9 @@ describe Tugboat::Middleware::FindImage do
 
   describe '.call' do
     it 'raises SystemExit with no image data' do
-      expect { described_class.new(app).call(env) }.to raise_error(SystemExit)
-
-      expect($stdout.string).to include 'Tugboat attempted to find an image with no arguments'
-      expect($stdout.string).to include 'For more help run: '
-      expect($stdout.string).to include 'Try running `tugboat '
+      expect { described_class.new(app).call(env) }.to raise_error(SystemExit).and output(%r{Tugboat attempted to find an image with no argument}).to_stdout
+      expect { described_class.new(app).call(env) }.to raise_error(SystemExit).and output(%r{For more help run:}).to_stdout
+      expect { described_class.new(app).call(env) }.to raise_error(SystemExit).and output(%r{Try running `tugboat}).to_stdout
     end
   end
 end

--- a/spec/middleware/ssh_droplet_spec.rb
+++ b/spec/middleware/ssh_droplet_spec.rb
@@ -21,7 +21,7 @@ describe Tugboat::Middleware::SSHDroplet do
       env['droplet_ip'] = droplet_ip
       env['config'] = config
 
-      described_class.new(app).call(env)
+      expect { described_class.new(app).call(env) }.to output(/SShing with options: -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=\/dev\/null -o IdentitiesOnly=yes -i #{File.expand_path(ssh_key_path)} -p 33 baz@33.33.33.10/).to_stdout
     end
 
     it 'exec ssh with IdentitiesOnly=no if no ssh_key_path in config' do
@@ -39,7 +39,7 @@ describe Tugboat::Middleware::SSHDroplet do
 
       env['config'] = config
 
-      described_class.new(app).call(env)
+      expect { described_class.new(app).call(env) }.to output(/SShing with options: -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=\/dev\/null -o IdentitiesOnly=no -p 33 baz@33.33.33.10/).to_stdout
     end
 
     it 'executes ssh with custom options' do
@@ -63,7 +63,7 @@ describe Tugboat::Middleware::SSHDroplet do
       env['user_droplet_use_public_ip'] = true
       env['user_droplet_ssh_opts'] = '-e -q -X'
 
-      described_class.new(app).call(env)
+      expect { described_class.new(app).call(env) }.to output(/SShing with options: -o LogLevel=ERROR -o StrictHostKeyChecking=no -o UserKnownHostsFile=\/dev\/null -o IdentitiesOnly=yes -i #{File.expand_path(ssh_key_path)} -p 33 -e -q -X baz@33.33.33.10 echo hello/).to_stdout
     end
 
     it 'executes ssh with private IP if option chosen' do
@@ -87,7 +87,7 @@ describe Tugboat::Middleware::SSHDroplet do
       env['user_droplet_use_private_ip'] = true
       env['user_droplet_ssh_opts'] = '-e -q -X'
 
-      described_class.new(app).call(env)
+      expect { described_class.new(app).call(env) }.to output(%r{You did! Using private IP for ssh...}).to_stdout
     end
 
     it 'errors if private IP option given but no Private IP on Droplet' do
@@ -97,9 +97,9 @@ describe Tugboat::Middleware::SSHDroplet do
       env['user_droplet_use_private_ip'] = true
       env['user_droplet_ssh_opts'] = '-e -q -X'
 
-      expect { described_class.new(app).call(env) }.to raise_error(SystemExit)
+      expect { described_class.new(app).call(env) }.to raise_error(SystemExit).and output(%r{You asked to ssh to the private IP, but no Private IP found}).to_stdout
 
-      expect($stdout.string).to eq <<-eos
+      expected_string = <<-eos
 Executing SSH on Droplet ...
 You asked to ssh to the private IP, but no Private IP found!
       eos

--- a/spec/shared/environment.rb
+++ b/spec/shared/environment.rb
@@ -27,26 +27,9 @@ shared_context 'spec' do
   let(:cli)                { Tugboat::CLI.new }
 
   before do
-    $stdout.sync = true
-    $stderr.sync = true
-
     # Set a temprary project path and create fake config.
     config.create_config_file(access_token, ssh_key_path, ssh_user, ssh_port, region, image, size, ssh_key_id, private_networking, backups_enabled, ip6, timeout)
     config.reload!
-
-    # Keep track of the old stderr / out
-    @orig_stderr = $stderr
-    @orig_stdout = $stdout
-
-    # Make them strings so we can manipulate and compare.
-    $stderr = StringIO.new
-    $stdout = StringIO.new
-  end
-
-  after do
-    # Reassign the stderr / out so rspec can have it back.
-    $stderr = @orig_stderr
-    $stdout = @orig_stdout
   end
 
   after do


### PR DESCRIPTION
* Rspec 3 adds the `output(args).to_stdout` method
* http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#new-output-matcher
* Means it’s a lot easier to do things like run pry, as stdout isn’t stuck
* Refactoring tests to change to next method