### PR TITLE
Bump Version to 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v4.0.0](https://github.com/petems/tugboat/tree/v4.0.0) (2017-12-03)
+[Full Changelog](https://github.com/petems/tugboat/compare/v3.1.0...v4.0.0)
+
+**Fixed bugs:**
+
+- snapshot not working [\#280](https://github.com/petems/tugboat/issues/280)
+- Release Tugboat for 2.4.1 support [\#279](https://github.com/petems/tugboat/issues/279)
+- Timeout while executing tugboat wait [\#71](https://github.com/petems/tugboat/issues/71)
+
+**Merged pull requests:**
+
+- Removing `Assigned but unused variable` warnings [\#292](https://github.com/petems/tugboat/pull/292) ([petems](https://github.com/petems))
+- Adds helper for showing snapshot parameter [\#290](https://github.com/petems/tugboat/pull/290) ([petems](https://github.com/petems))
+- Updates Faraday middleware gem [\#289](https://github.com/petems/tugboat/pull/289) ([petems](https://github.com/petems))
+- Create CODE\_OF\_CONDUCT.md [\#288](https://github.com/petems/tugboat/pull/288) ([petems](https://github.com/petems))
+- Add Size Slug [\#287](https://github.com/petems/tugboat/pull/287) ([petems](https://github.com/petems))
+- Changes debug output to allow multiple regex [\#286](https://github.com/petems/tugboat/pull/286) ([petems](https://github.com/petems))
+- Switches `$stdout` redirection to rspec method [\#285](https://github.com/petems/tugboat/pull/285) ([petems](https://github.com/petems))
+- Change listing droplets to use DK [\#284](https://github.com/petems/tugboat/pull/284) ([petems](https://github.com/petems))
+- Add configurable timeout to config file [\#283](https://github.com/petems/tugboat/pull/283) ([petems](https://github.com/petems))
+
 ## [v3.1.0](https://github.com/petems/tugboat/tree/v3.1.0) (2017-07-13)
 [Full Changelog](https://github.com/petems/tugboat/compare/v3.0.0...v3.1.0)
 
@@ -334,7 +355,7 @@ All notable changes to this project will be documented in this file.
 
 - destroy and info command [\#91](https://github.com/petems/tugboat/pull/91) ([PierreFrisch](https://github.com/PierreFrisch))
 - Add rebuild command [\#90](https://github.com/petems/tugboat/pull/90) ([PierreFrisch](https://github.com/PierreFrisch))
-- Fuzzy name searching is now case insensitive [\#88](https://github.com/petems/tugboat/pull/88) ([Vel0x](https://github.com/Vel0x))
+- Fuzzy name searching is now case insensitive [\#88](https://github.com/petems/tugboat/pull/88) ([dalemyers](https://github.com/dalemyers))
 - global: add a -q/--quiet flag [\#87](https://github.com/petems/tugboat/pull/87) ([pearkes](https://github.com/pearkes))
 - Add backups\_enabled option on droplet creation \(-b true\) [\#82](https://github.com/petems/tugboat/pull/82) ([4n3w](https://github.com/4n3w))
 

--- a/lib/tugboat/version.rb
+++ b/lib/tugboat/version.rb
@@ -1,3 +1,3 @@
 module Tugboat
-  VERSION = '3.1.0'.freeze
+  VERSION = '4.0.0'.freeze
 end


### PR DESCRIPTION
Major version bump as we're moving a lot of the core Droplet listing logic to the new API so possible breaking changes there, as well as adding in a new size slug to the output