### PR TITLE
Adds porcelain option to droplets command

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,44 @@ defaults:
     pearkes-admin-001 (ip: 30.30.30.3, status: active, region: nyc2, id: 13231512)
     pearkes-api-001 (ip: 30.30.30.5, status: active, region: nyc2, id: 13231513)
 
+If you wish to use the droplet listing as part of scripting or munging output, you can use the `--porcelain`:
+
+    $ tugboat droplets --attribute=ip4
+    pearkes-web-001,30.30.30.1
+    pearkes-admin-001,30.30.30.3
+    pearkes-api-001,30.30.30.5
+
+Or `--attribute` parameter:
+
+    $ tugboat droplets --porcelain
+    name pearkes-web-001
+    id 13231515
+    status active
+    ip4 330.30.30.1
+    region lon1
+    image 6918990
+    size 1gb
+    backups_active false
+
+    name pearkes-admin-001
+    id 13231513
+    status active
+    ip4 30.30.30.3
+    region lon1
+    image 6918990
+    size 1gb
+    backups_active false
+
+    name pearkes-web-001
+    id 13231514
+    status active
+    ip4 30.30.30.5
+    region lon1
+    image 6918990
+    size 1gb
+    backups_active true
+
+
 ### Fuzzy name matching
 
 You can pass a unique fragment of a droplets name for interactions

--- a/lib/tugboat/cli.rb
+++ b/lib/tugboat/cli.rb
@@ -71,12 +71,26 @@ module Tugboat
                   default: 20,
                   aliases: '-p',
                   desc: 'Chose how many results to fetch from the DigitalOcean API (larger is slower)'
+    method_option 'attribute',
+                  type: :string,
+                  aliases: '-a',
+                  desc: 'The name of the attribute to print.'
+    method_option 'porcelain',
+                  type: :boolean,
+                  desc: 'Give the output in an easy-to-parse format for scripts.'
+    method_option 'include_name',
+                  type: :boolean,
+                  default: true,
+                  desc: 'Include the name when listing attributes from droplets.'
     desc 'droplets [OPTIONS]', 'Retrieve a list of your droplets'
     def droplets
       Middleware.sequence_list_droplets.call('tugboat_action' => __method__,
                                              'user_quiet' => options[:quiet],
                                              'include_urls' => options['include_urls'],
-                                             'per_page' => options['per_page'],)
+                                             'per_page' => options['per_page'],
+                                             'attribute' => options[:attribute],
+                                             'porcelain' => options[:porcelain],
+                                             'include_name' => options[:include_name])
     end
 
     desc 'images [OPTIONS]', 'Retrieve a list of images'

--- a/lib/tugboat/middleware/list_droplets.rb
+++ b/lib/tugboat/middleware/list_droplets.rb
@@ -14,20 +14,7 @@ module Tugboat
         droplet_list.each do |droplet|
           has_one = true
 
-          private_addr = droplet.networks.v4.find { |address| address.type == 'private' }
-          if private_addr
-            private_ip = ", private_ip: #{private_addr.ip_address}"
-          end
-
-          status_color = if droplet.status == 'active'
-                           GREEN
-                         else
-                           RED
-                         end
-
-          public_addr = droplet.networks.v4.find { |address| address.type == 'public' }
-
-          say "#{droplet.name} (ip: #{public_addr.ip_address}#{private_ip}, status: #{status_color}#{droplet.status}#{CLEAR}, region: #{droplet.region.slug}, size: #{droplet.size_slug}, id: #{droplet.id}#{env['include_urls'] ? droplet_id_to_url(droplet.id) : ''})"
+          print_droplet_info(droplet, env['attribute'], env['porcelain'], env['include_urls'], env['include_name'])
         end
 
         unless has_one

--- a/spec/cli/droplets_cli_spec.rb
+++ b/spec/cli/droplets_cli_spec.rb
@@ -137,6 +137,154 @@ page2example3.com (ip: 104.236.32.173, status: \e[31moff\e[0m, region: nyc3, siz
       expect(a_request(:get, 'https://api.digitalocean.com/v2/droplets?page=2&per_page=3')).to have_been_made
     end
 
+    it 'gives porcelain output when set' do
+      stub_request(:get, 'https://api.digitalocean.com/v2/droplets?page=1&per_page=1').
+        with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
+        to_return(status: 200, body: fixture('show_droplets'), headers: {})
+
+      stub_request(:get, 'https://api.digitalocean.com/v2/droplets?page=1&per_page=20').
+        with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
+        to_return(status: 200, body: fixture('show_droplets'), headers: { 'Content-Type' => 'application/json' })
+
+      cli.options = cli.options.merge('porcelain' => true)
+
+      expected_string = <<-eos
+name example.com
+id 6918990
+status active
+ip4 104.236.32.182
+ip6 2604:A880:0800:0010:0000:0000:02DD:4001
+region nyc3
+image 6918990
+size 512mb
+backups_active true
+
+name example2.com
+id 3164956
+status active
+ip4 104.236.32.172
+ip6 2604:A880:0800:0010:0000:0000:02DD:4001
+region nyc3
+image 6918990
+size 512mb
+backups_active true
+
+name example3.com
+id 3164444
+status off
+ip4 104.236.32.173
+ip6 2604:A880:0800:0010:0000:0000:02DD:4001
+region nyc3
+image 6918990
+size 512mb
+backups_active true
+
+      eos
+
+      expect { cli.droplets }.to output(expected_string).to_stdout
+
+      expect(a_request(:get, 'https://api.digitalocean.com/v2/droplets?page=1&per_page=1')).to have_been_made.twice
+      expect(a_request(:get, 'https://api.digitalocean.com/v2/droplets?page=1&per_page=20')).to have_been_made
+    end
+
+    it 'gives ipv4 attribute output when set' do
+      stub_request(:get, 'https://api.digitalocean.com/v2/droplets?page=1&per_page=1').
+        with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
+        to_return(status: 200, body: fixture('show_droplets'), headers: {})
+
+      stub_request(:get, 'https://api.digitalocean.com/v2/droplets?page=1&per_page=20').
+        with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
+        to_return(status: 200, body: fixture('show_droplets'), headers: { 'Content-Type' => 'application/json' })
+
+      cli.options = cli.options.merge('attribute' => 'ip4', 'include_name' => true)
+
+      expected_string = <<-eos
+example.com,104.236.32.182
+example2.com,104.236.32.172
+example3.com,104.236.32.173
+      eos
+
+      expect { cli.droplets }.to output(expected_string).to_stdout
+
+      expect(a_request(:get, 'https://api.digitalocean.com/v2/droplets?page=1&per_page=1')).to have_been_made.twice
+      expect(a_request(:get, 'https://api.digitalocean.com/v2/droplets?page=1&per_page=20')).to have_been_made
+    end
+
+    it 'gives status attribute output when set' do
+      stub_request(:get, 'https://api.digitalocean.com/v2/droplets?page=1&per_page=1').
+        with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
+        to_return(status: 200, body: fixture('show_droplets'), headers: {})
+
+      stub_request(:get, 'https://api.digitalocean.com/v2/droplets?page=1&per_page=20').
+        with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
+        to_return(status: 200, body: fixture('show_droplets'), headers: { 'Content-Type' => 'application/json' })
+
+      cli.options = cli.options.merge('attribute' => 'status', 'include_name' => true)
+
+      expected_string = <<-eos
+example.com,active
+example2.com,active
+example3.com,off
+      eos
+
+      expect { cli.droplets }.to output(expected_string).to_stdout
+
+      expect(a_request(:get, 'https://api.digitalocean.com/v2/droplets?page=1&per_page=1')).to have_been_made.twice
+      expect(a_request(:get, 'https://api.digitalocean.com/v2/droplets?page=1&per_page=20')).to have_been_made
+    end
+
+    it 'gives only ip4 attribute output when set and include_name set to false' do
+      stub_request(:get, 'https://api.digitalocean.com/v2/droplets?page=1&per_page=1').
+        with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
+        to_return(status: 200, body: fixture('show_droplets'), headers: {})
+
+      stub_request(:get, 'https://api.digitalocean.com/v2/droplets?page=1&per_page=20').
+        with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
+        to_return(status: 200, body: fixture('show_droplets'), headers: { 'Content-Type' => 'application/json' })
+
+      cli.options = cli.options.merge('attribute' => 'ip4', 'include_name' => false)
+
+      expected_string = <<-eos
+104.236.32.182
+104.236.32.172
+104.236.32.173
+      eos
+
+      expect { cli.droplets }.to output(expected_string).to_stdout
+
+      expect(a_request(:get, 'https://api.digitalocean.com/v2/droplets?page=1&per_page=1')).to have_been_made.twice
+      expect(a_request(:get, 'https://api.digitalocean.com/v2/droplets?page=1&per_page=20')).to have_been_made
+    end
+
+    it 'shows error if attribute asked for does not exist' do
+      stub_request(:get, 'https://api.digitalocean.com/v2/droplets?page=1&per_page=1').
+        with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
+        to_return(status: 200, body: fixture('show_droplets'), headers: {})
+
+      stub_request(:get, 'https://api.digitalocean.com/v2/droplets?page=1&per_page=20').
+        with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).
+        to_return(status: 200, body: fixture('show_droplets'), headers: { 'Content-Type' => 'application/json' })
+
+      cli.options = cli.options.merge('attribute' => 'foo')
+
+      expected_string = <<-eos
+Invalid attribute \"foo\"
+Provide one of the following:
+    name
+    id
+    status
+    ip4
+    ip6
+    private_ip
+    region
+    image
+    size
+    backups_active
+      eos
+
+      expect { cli.droplets }.to raise_error(SystemExit).and output(expected_string).to_stdout
+    end
+
     it 'shows error on failure in initial stage' do
       stub_request(:get, 'https://api.digitalocean.com/v2/droplets?page=1&per_page=1').
         with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization' => 'Bearer foo', 'Content-Type' => 'application/json', 'User-Agent' => 'Faraday v0.9.2' }).


### PR DESCRIPTION
* Easier output for things like sed, awk and cut
* Example from `tugboat droplets | grep -F TEST | cut -d : -f 2 | cut -d ' ' -f 2 | cut -d , -f 1 >>big-test-hosts`
* This would now be accomplished with something as easy as:
```
bundle exec tugboat droplets --attribute=ip4
test-blog-1,41.101.11.22
test-blog-2,138.68.11.22
```